### PR TITLE
Redirect Instagram/Facebook in-app browsers to Bluesky

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,3 +1,13 @@
+<script>
+  // Redirect visitors arriving from the Instagram or Facebook in-app
+  // browsers (which break many web features) over to Bluesky.
+  (function () {
+    var ua = navigator.userAgent || "";
+    if (/Instagram|FBAN|FBAV|FB_IAB/.test(ua)) {
+      window.location.replace("https://bsky.app/profile/philihp.com");
+    }
+  })();
+</script>
 <link
   rel="apple-touch-icon"
   sizes="180x180"


### PR DESCRIPTION
## Summary

Visitors who arrive from the Instagram or Facebook in-app browsers are now redirected to https://bsky.app/profile/philihp.com.

Because this is a static Jekyll/GitHub Pages site, the detection runs client-side. A small inline script in `_includes/head_custom.html` (which is loaded in the `<head>` of every page) checks `navigator.userAgent` for the in-app browser signatures and, on a match, calls `window.location.replace(...)` so the redirect doesn't leave an extra entry in the history stack.

The user-agent patterns matched:
- `Instagram` — Instagram in-app browser
- `FBAN` / `FBAV` / `FB_IAB` — Facebook in-app browser identifiers

## Notes

The script lives in the document head and runs before the page renders, so the redirect happens as early as possible.

https://claude.ai/code/session_012CY7jduKgtCV62mqk2epEv

---
_Generated by [Claude Code](https://claude.ai/code/session_012CY7jduKgtCV62mqk2epEv)_