### PR TITLE
Add Levantar nonprofit demo site with GA event tracking

### DIFF
--- a/public/levantar/donate.html
+++ b/public/levantar/donate.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Donate — Levantar</title>
+
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-XXXXXXXXXX');
+</script>
+
+<style>
+  * { box-sizing: border-box; }
+  body { margin:0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; color:#222; background:#f7f5f0; line-height:1.6; }
+  header { background:#2a7a5b; color:white; padding:1rem 2rem; display:flex; justify-content:space-between; align-items:center; }
+  header h1 { margin:0; font-size:1.5rem; }
+  nav a { color:white; margin-left:1.5rem; text-decoration:none; font-weight:500; }
+  main { max-width:560px; margin:2rem auto; padding:2.5rem; background:white; border-radius:8px; box-shadow:0 2px 6px rgba(0,0,0,0.06); }
+  h2 { color:#1f5a43; margin-top:0; }
+  label { display:block; margin-top:1.2rem; font-weight:600; }
+  input[type="email"] { width:100%; padding:0.7rem; font-size:1rem; border:1px solid #ccc; border-radius:5px; margin-top:0.3rem; }
+  input[type="email"]:focus { outline:none; border-color:#2a7a5b; box-shadow:0 0 0 3px rgba(42,122,91,0.15); }
+  .amounts { display:grid; grid-template-columns:repeat(4,1fr); gap:0.6rem; margin-top:0.6rem; }
+  .amount-btn { padding:0.9rem; font-size:1rem; border:2px solid #2a7a5b; background:white; color:#2a7a5b; border-radius:6px; cursor:pointer; font-weight:600; }
+  .amount-btn.selected, .amount-btn:hover { background:#2a7a5b; color:white; }
+  .btn { display:inline-block; background:#2a7a5b; color:white; padding:0.9rem 1.8rem; border-radius:6px; border:none; cursor:pointer; font-size:1rem; font-weight:600; margin-top:1.5rem; }
+  .btn:hover { background:#1f5a43; }
+  .btn:disabled { background:#aaa; cursor:not-allowed; }
+  footer { text-align:center; padding:2rem; color:#666; font-size:0.9rem; }
+</style>
+</head>
+<body>
+<header>
+  <h1>Levantar</h1>
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="volunteer.html">Volunteer</a>
+    <a href="donate.html">Donate</a>
+  </nav>
+</header>
+
+<main>
+  <h2>Support Our Mission</h2>
+  <p>Every dollar helps us serve more meals, fund more programs, and lift more lives.</p>
+
+  <form id="donate-form" action="thank-you.html" method="get">
+    <label for="email">Email Address
+      <input type="email" id="email" name="email" required placeholder="you@example.com" />
+    </label>
+
+    <label>Choose an Amount</label>
+    <div class="amounts">
+      <button type="button" class="amount-btn" data-amount="10">$10</button>
+      <button type="button" class="amount-btn" data-amount="25">$25</button>
+      <button type="button" class="amount-btn" data-amount="50">$50</button>
+      <button type="button" class="amount-btn" data-amount="100">$100</button>
+    </div>
+    <input type="hidden" id="amount" name="amount" value="" />
+
+    <button type="submit" id="submit-btn" class="btn" disabled>Donate</button>
+  </form>
+</main>
+
+<footer>&copy; 2026 Levantar. A demo nonprofit for educational purposes.</footer>
+
+<script>
+  document.getElementById('email').addEventListener('click', function() {
+    gtag('event', 'form_field_click', { form_name: 'donate', field_name: 'email' });
+  });
+
+  var amountInput = document.getElementById('amount');
+  var submitBtn = document.getElementById('submit-btn');
+  document.querySelectorAll('.amount-btn').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      var amount = btn.getAttribute('data-amount');
+      document.querySelectorAll('.amount-btn').forEach(function(b){ b.classList.remove('selected'); });
+      btn.classList.add('selected');
+      amountInput.value = amount;
+      submitBtn.disabled = false;
+      gtag('event', 'form_field_click', { form_name: 'donate', field_name: 'amount', amount: Number(amount) });
+    });
+  });
+
+  submitBtn.addEventListener('click', function() {
+    gtag('event', 'form_submit_click', { form_name: 'donate', amount: Number(amountInput.value) });
+  });
+</script>
+</body>
+</html>

--- a/public/levantar/index.html
+++ b/public/levantar/index.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Levantar — Lifting Communities Together</title>
+
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-XXXXXXXXXX');
+</script>
+
+<style>
+  :root { --brand:#2a7a5b; --brand-dark:#1f5a43; --bg:#f7f5f0; --text:#222; }
+  * { box-sizing: border-box; }
+  body { margin:0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; color:var(--text); background:var(--bg); line-height:1.6; }
+  header { background:var(--brand); color:white; padding:1rem 2rem; display:flex; justify-content:space-between; align-items:center; }
+  header h1 { margin:0; font-size:1.5rem; }
+  nav a { color:white; margin-left:1.5rem; text-decoration:none; font-weight:500; }
+  nav a:hover { text-decoration:underline; }
+  .hero { padding:4rem 2rem; text-align:center; background:linear-gradient(135deg,#e8f0eb,#f7f5f0); }
+  .hero h2 { font-size:2.5rem; margin:0 0 1rem; color:var(--brand-dark); }
+  .hero p { font-size:1.2rem; max-width:600px; margin:0 auto 2rem; }
+  .btn { display:inline-block; background:var(--brand); color:white; padding:0.9rem 1.8rem; border-radius:6px; text-decoration:none; font-weight:600; margin:0.5rem; border:none; cursor:pointer; font-size:1rem; }
+  .btn:hover { background:var(--brand-dark); }
+  .btn.secondary { background:white; color:var(--brand); border:2px solid var(--brand); }
+  main { max-width:900px; margin:0 auto; padding:3rem 2rem; }
+  .cards { display:grid; grid-template-columns:repeat(auto-fit,minmax(240px,1fr)); gap:1.5rem; margin-top:2rem; }
+  .card { background:white; padding:1.5rem; border-radius:8px; box-shadow:0 2px 6px rgba(0,0,0,0.06); }
+  .card h3 { margin-top:0; color:var(--brand-dark); }
+  footer { text-align:center; padding:2rem; color:#666; font-size:0.9rem; }
+</style>
+</head>
+<body>
+<header>
+  <h1>Levantar</h1>
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="volunteer.html">Volunteer</a>
+    <a href="donate.html">Donate</a>
+  </nav>
+</header>
+
+<section class="hero">
+  <h2>Lifting Communities, One Step at a Time</h2>
+  <p>Levantar is dedicated to empowering underserved neighborhoods through education, food security, and opportunity.</p>
+  <a href="volunteer.html" class="btn">Volunteer With Us</a>
+  <a href="donate.html" class="btn secondary">Donate Now</a>
+</section>
+
+<main>
+  <h2>Our Mission</h2>
+  <p>We believe every community deserves the chance to rise. Through partnerships with local schools, food banks, and small businesses, we provide resources to those who need them most.</p>
+
+  <div class="cards">
+    <div class="card"><h3>5,000+</h3><p>Meals served last year</p></div>
+    <div class="card"><h3>300+</h3><p>Active volunteers</p></div>
+    <div class="card"><h3>12</h3><p>Community partners</p></div>
+  </div>
+</main>
+
+<footer>&copy; 2026 Levantar. A demo nonprofit for educational purposes.</footer>
+</body>
+</html>

--- a/public/levantar/success.html
+++ b/public/levantar/success.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Welcome Aboard — Levantar</title>
+
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-XXXXXXXXXX');
+  gtag('event', 'volunteer_signup_success');
+</script>
+
+<style>
+  * { box-sizing: border-box; }
+  body { margin:0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; color:#222; background:#f7f5f0; line-height:1.6; }
+  header { background:#2a7a5b; color:white; padding:1rem 2rem; display:flex; justify-content:space-between; align-items:center; }
+  header h1 { margin:0; font-size:1.5rem; }
+  nav a { color:white; margin-left:1.5rem; text-decoration:none; font-weight:500; }
+  main { max-width:560px; margin:3rem auto; padding:3rem; background:white; border-radius:8px; box-shadow:0 2px 6px rgba(0,0,0,0.06); text-align:center; }
+  h2 { color:#1f5a43; margin-top:0; font-size:2rem; }
+  .checkmark { font-size:4rem; color:#2a7a5b; }
+  .btn { display:inline-block; background:#2a7a5b; color:white; padding:0.9rem 1.8rem; border-radius:6px; text-decoration:none; font-weight:600; margin-top:1.5rem; }
+  footer { text-align:center; padding:2rem; color:#666; font-size:0.9rem; }
+</style>
+</head>
+<body>
+<header>
+  <h1>Levantar</h1>
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="volunteer.html">Volunteer</a>
+    <a href="donate.html">Donate</a>
+  </nav>
+</header>
+
+<main>
+  <div class="checkmark">&#10004;</div>
+  <h2>You're In!</h2>
+  <p>Thanks for signing up to volunteer with Levantar. We'll be in touch within 48 hours with opportunities in your area.</p>
+  <a href="index.html" class="btn">Back to Home</a>
+</main>
+
+<footer>&copy; 2026 Levantar. A demo nonprofit for educational purposes.</footer>
+</body>
+</html>

--- a/public/levantar/thank-you.html
+++ b/public/levantar/thank-you.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Thank You — Levantar</title>
+
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-XXXXXXXXXX');
+
+  var params = new URLSearchParams(window.location.search);
+  var amount = Number(params.get('amount')) || 0;
+  gtag('event', 'donation_success', { amount: amount, currency: 'USD' });
+</script>
+
+<style>
+  * { box-sizing: border-box; }
+  body { margin:0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; color:#222; background:#f7f5f0; line-height:1.6; }
+  header { background:#2a7a5b; color:white; padding:1rem 2rem; display:flex; justify-content:space-between; align-items:center; }
+  header h1 { margin:0; font-size:1.5rem; }
+  nav a { color:white; margin-left:1.5rem; text-decoration:none; font-weight:500; }
+  main { max-width:560px; margin:3rem auto; padding:3rem; background:white; border-radius:8px; box-shadow:0 2px 6px rgba(0,0,0,0.06); text-align:center; }
+  h2 { color:#1f5a43; margin-top:0; font-size:2rem; }
+  .heart { font-size:4rem; color:#e25c5c; }
+  .btn { display:inline-block; background:#2a7a5b; color:white; padding:0.9rem 1.8rem; border-radius:6px; text-decoration:none; font-weight:600; margin-top:1.5rem; }
+  footer { text-align:center; padding:2rem; color:#666; font-size:0.9rem; }
+</style>
+</head>
+<body>
+<header>
+  <h1>Levantar</h1>
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="volunteer.html">Volunteer</a>
+    <a href="donate.html">Donate</a>
+  </nav>
+</header>
+
+<main>
+  <div class="heart">&#10084;</div>
+  <h2>Thank You For Your Donation!</h2>
+  <p>Your generosity makes our work possible. A receipt is on its way to your inbox.</p>
+  <a href="index.html" class="btn">Back to Home</a>
+</main>
+
+<footer>&copy; 2026 Levantar. A demo nonprofit for educational purposes.</footer>
+</body>
+</html>

--- a/public/levantar/volunteer.html
+++ b/public/levantar/volunteer.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Volunteer — Levantar</title>
+
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-XXXXXXXXXX');
+</script>
+
+<style>
+  * { box-sizing: border-box; }
+  body { margin:0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; color:#222; background:#f7f5f0; line-height:1.6; }
+  header { background:#2a7a5b; color:white; padding:1rem 2rem; display:flex; justify-content:space-between; align-items:center; }
+  header h1 { margin:0; font-size:1.5rem; }
+  nav a { color:white; margin-left:1.5rem; text-decoration:none; font-weight:500; }
+  main { max-width:560px; margin:2rem auto; padding:2.5rem; background:white; border-radius:8px; box-shadow:0 2px 6px rgba(0,0,0,0.06); }
+  h2 { color:#1f5a43; margin-top:0; }
+  label { display:block; margin-top:1.2rem; font-weight:600; }
+  input { width:100%; padding:0.7rem; font-size:1rem; border:1px solid #ccc; border-radius:5px; margin-top:0.3rem; }
+  input:focus { outline:none; border-color:#2a7a5b; box-shadow:0 0 0 3px rgba(42,122,91,0.15); }
+  .btn { display:inline-block; background:#2a7a5b; color:white; padding:0.9rem 1.8rem; border-radius:6px; border:none; cursor:pointer; font-size:1rem; font-weight:600; margin-top:1.5rem; }
+  .btn:hover { background:#1f5a43; }
+  footer { text-align:center; padding:2rem; color:#666; font-size:0.9rem; }
+</style>
+</head>
+<body>
+<header>
+  <h1>Levantar</h1>
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="volunteer.html">Volunteer</a>
+    <a href="donate.html">Donate</a>
+  </nav>
+</header>
+
+<main>
+  <h2>Become a Volunteer</h2>
+  <p>Join our team of changemakers. Fill out the form and we'll reach out with opportunities near you.</p>
+
+  <form id="volunteer-form" action="success.html" method="get">
+    <label for="email">Email Address
+      <input type="email" id="email" name="email" required placeholder="you@example.com" />
+    </label>
+
+    <label for="phone">Phone Number
+      <input type="tel" id="phone" name="phone" required placeholder="(555) 555-5555" />
+    </label>
+
+    <button type="submit" id="submit-btn" class="btn">Sign Up to Volunteer</button>
+  </form>
+</main>
+
+<footer>&copy; 2026 Levantar. A demo nonprofit for educational purposes.</footer>
+
+<script>
+  document.getElementById('email').addEventListener('click', function() {
+    gtag('event', 'form_field_click', { form_name: 'volunteer', field_name: 'email' });
+  });
+  document.getElementById('phone').addEventListener('click', function() {
+    gtag('event', 'form_field_click', { form_name: 'volunteer', field_name: 'phone' });
+  });
+  document.getElementById('submit-btn').addEventListener('click', function() {
+    gtag('event', 'form_submit_click', { form_name: 'volunteer' });
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Five-page static demo site under `/public/levantar/` for teaching students how to measure impact via Google Analytics:

- `index.html` — landing page for the (ambiguous) Levantar nonprofit
- `volunteer.html` — email + phone signup form
- `success.html` — post-signup confirmation (fires `volunteer_signup_success`)
- `donate.html` — email + amount-button donation form
- `thank-you.html` — post-donation confirmation (fires `donation_success` with amount)

## GA tracking
Every page loads `gtag.js` with placeholder ID `G-XXXXXXXXXX` — replace with the class's real measurement ID. Form fields fire `form_field_click` events on click, and submit buttons fire `form_submit_click`. Donation amount buttons additionally include the selected amount in the event payload, so students can A/B test changes (button copy, ordering, default selection) and watch the funnel shift in GA.

## Test plan
- [ ] Replace `G-XXXXXXXXXX` with a real GA4 measurement ID
- [ ] Visit each page locally and confirm navigation flows
- [ ] Open GA DebugView and verify `form_field_click`, `form_submit_click`, `volunteer_signup_success`, and `donation_success` events fire


---
_Generated by [Claude Code](https://claude.ai/code/session_012RmjFyUbceJq51AGC56Wdi)_