### PR TITLE
Add live /sun and /moon position pages

### DIFF
--- a/app/_meta.global.js
+++ b/app/_meta.global.js
@@ -17,5 +17,15 @@ export default {
   lightning: {
     type: 'page',
     title: 'Lightning'
+  },
+  sun: {
+    type: 'page',
+    title: 'Sun',
+    href: '/sun'
+  },
+  moon: {
+    type: 'page',
+    title: 'Moon',
+    href: '/moon'
   }
 }

--- a/app/geo.js
+++ b/app/geo.js
@@ -1,0 +1,111 @@
+import { cookies, headers } from 'next/headers'
+
+// Shared location resolution for the /sun and /moon pages: the Vercel
+// IP-derived estimate from the request headers, plus the more accurate
+// device location the browser may have shared via the "Use my device
+// location" button (stored in the `device-geo` cookie).
+
+export const parseFloatOrNull = raw => {
+  if (raw === undefined || raw === null || raw.trim() === '') return null
+  const n = Number(raw)
+  return Number.isFinite(n) ? n : null
+}
+
+const decodeHeader = raw => {
+  if (raw === undefined || raw === null || raw.trim() === '') return null
+  try {
+    return decodeURIComponent(raw)
+  } catch {
+    return raw
+  }
+}
+
+// Reverse-geocode a coordinate to "city, state, COUNTRY" via OpenStreetMap's
+// Nominatim service. Returns null on any failure so the page still renders.
+const reverseGeocode = async (lat, lon) => {
+  try {
+    const res = await fetch(
+      `https://nominatim.openstreetmap.org/reverse?format=jsonv2&lat=${lat}&lon=${lon}&zoom=10`,
+      {
+        cache: 'no-store',
+        headers: { 'User-Agent': 'philihp.com/sun-moon-pages' }
+      }
+    )
+    if (!res.ok) return null
+    const data = await res.json()
+    const a = data.address ?? {}
+    const city =
+      a.city ?? a.town ?? a.village ?? a.hamlet ?? a.county ?? a.suburb
+    const parts = [
+      city,
+      a.state,
+      typeof a.country_code === 'string'
+        ? a.country_code.toUpperCase()
+        : a.country
+    ].filter(p => typeof p === 'string' && p.length > 0)
+    return parts.length > 0 ? parts.join(', ') : null
+  } catch {
+    return null
+  }
+}
+
+export const resolveLocation = async () => {
+  // Vercel populates these geolocation headers automatically from the
+  // visitor's IP. Fall back to env vars so it also works in local dev.
+  const h = await headers()
+  const lat =
+    parseFloatOrNull(h.get('x-vercel-ip-latitude')) ??
+    parseFloatOrNull(process.env.VERCEL_LATITUDE ?? process.env.LATITUDE)
+  const lon =
+    parseFloatOrNull(h.get('x-vercel-ip-longitude')) ??
+    parseFloatOrNull(process.env.VERCEL_LONGITUDE ?? process.env.LONGITUDE)
+
+  // Vercel's estimate of the place behind that IP. The city is URL-encoded.
+  const place = [
+    decodeHeader(h.get('x-vercel-ip-city')),
+    decodeHeader(h.get('x-vercel-ip-country-region')),
+    decodeHeader(h.get('x-vercel-ip-country'))
+  ]
+    .filter(part => part !== null)
+    .join(', ')
+
+  // Location the browser shared via the "Use my device location" button,
+  // saved to a cookie so we can compare it against the Vercel IP estimate.
+  const cookieStore = await cookies()
+  let deviceLat = null
+  let deviceLon = null
+  const deviceRaw = cookieStore.get('device-geo')?.value
+  if (deviceRaw) {
+    try {
+      const parsed = JSON.parse(decodeURIComponent(deviceRaw))
+      deviceLat = parseFloatOrNull(String(parsed.lat))
+      deviceLon = parseFloatOrNull(String(parsed.lon))
+    } catch {
+      // Ignore a malformed cookie.
+    }
+  }
+
+  // For a user-provided location, reverse-geocode it to a city.
+  const devicePlace =
+    deviceLat !== null && deviceLon !== null
+      ? await reverseGeocode(deviceLat, deviceLon)
+      : null
+
+  // Compute from the browser-shared device location when we have it: it is
+  // the visitor's actual position, whereas the Vercel headers are only an IP
+  // estimate that can be hundreds of kilometres off (enough to flip the sun
+  // or moon above/below the horizon). Fall back to the IP estimate otherwise.
+  const usingDeviceLocation = deviceLat !== null && deviceLon !== null
+
+  return {
+    lat,
+    lon,
+    place,
+    deviceLat,
+    deviceLon,
+    devicePlace,
+    effLat: deviceLat ?? lat,
+    effLon: deviceLon ?? lon,
+    usingDeviceLocation
+  }
+}

--- a/app/location-table.jsx
+++ b/app/location-table.jsx
@@ -1,0 +1,60 @@
+import { Table } from 'nextra/components'
+import { LiveClock } from './sun/live'
+import { fmt } from './sun/solar'
+
+// The "Location & Time" table shared by the /sun and /moon pages. Shows the
+// Vercel IP estimate until the visitor shares their device location, which is
+// more accurate and replaces it.
+export default function LocationTable({ loc }) {
+  const { lat, lon, place, deviceLat, deviceLon, devicePlace } = loc
+  return (
+    <Table>
+      <tbody>
+        {!loc.usingDeviceLocation && (
+          <>
+            <Table.Tr>
+              <Table.Th>Latitude</Table.Th>
+              <Table.Td>
+                {lat !== null ? `${fmt(lat, 4)}°` : <em>unavailable</em>}
+              </Table.Td>
+            </Table.Tr>
+            <Table.Tr>
+              <Table.Th>Longitude</Table.Th>
+              <Table.Td>
+                {lon !== null ? `${fmt(lon, 4)}°` : <em>unavailable</em>}
+              </Table.Td>
+            </Table.Tr>
+            <Table.Tr>
+              <Table.Th>Nearest city / state / country</Table.Th>
+              <Table.Td>{place !== '' ? place : <em>unavailable</em>}</Table.Td>
+            </Table.Tr>
+          </>
+        )}
+        <Table.Tr>
+          <Table.Th>Device latitude (browser)</Table.Th>
+          <Table.Td>
+            {deviceLat !== null ? `${fmt(deviceLat, 4)}°` : <em>not shared</em>}
+          </Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+          <Table.Th>Device longitude (browser)</Table.Th>
+          <Table.Td>
+            {deviceLon !== null ? `${fmt(deviceLon, 4)}°` : <em>not shared</em>}
+          </Table.Td>
+        </Table.Tr>
+        {loc.usingDeviceLocation && (
+          <Table.Tr>
+            <Table.Th>Device city (reverse lookup)</Table.Th>
+            <Table.Td>{devicePlace ?? <em>unavailable</em>}</Table.Td>
+          </Table.Tr>
+        )}
+        <Table.Tr>
+          <Table.Th>Time (UTC)</Table.Th>
+          <Table.Td>
+            <LiveClock />
+          </Table.Td>
+        </Table.Tr>
+      </tbody>
+    </Table>
+  )
+}

--- a/app/moon/live.jsx
+++ b/app/moon/live.jsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { Table } from 'nextra/components'
+import { useNow } from '../sun/live'
+import { compass, fmt } from '../sun/solar'
+import { moonPosition } from './moon'
+
+export function LiveMoon({ lat, lon }) {
+  const now = useNow()
+
+  if (lat === null || lon === null) {
+    return (
+      <p>
+        No location available. On Vercel this comes from the{' '}
+        <code>x-vercel-ip-latitude</code> / <code>x-vercel-ip-longitude</code>{' '}
+        headers; locally, set the <code>LATITUDE</code> and{' '}
+        <code>LONGITUDE</code> environment variables.
+      </p>
+    )
+  }
+
+  const moon = moonPosition(now, lat, lon)
+  return (
+    <Table>
+      <tbody>
+        <Table.Tr>
+          <Table.Th>Phase</Table.Th>
+          <Table.Td>
+            {moon.phase} ({fmt(moon.illumination, 1)}% illuminated)
+          </Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+          <Table.Th>Azimuth (angle in the sky)</Table.Th>
+          <Table.Td>
+            {fmt(moon.azimuth)}° ({compass(moon.azimuth)})
+          </Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+          <Table.Th>Elevation / inclination above horizon</Table.Th>
+          <Table.Td>
+            {fmt(moon.elevation)}°{' '}
+            {moon.elevation < 0 && <em>(below the horizon)</em>}
+          </Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+          <Table.Th>Distance</Table.Th>
+          <Table.Td>{fmt(moon.distanceKm, 0)} km</Table.Td>
+        </Table.Tr>
+      </tbody>
+    </Table>
+  )
+}

--- a/app/moon/moon.js
+++ b/app/moon/moon.js
@@ -1,0 +1,142 @@
+// Low-precision lunar position, ported from Paul Schlyter's "Computing
+// planetary positions" (https://stjarnhimlen.se/comp/ppcomp.html). Accurate to
+// a few arc-minutes — plenty for showing where the Moon is in the sky.
+
+const DEG = 180 / Math.PI
+const rad = Math.PI / 180
+
+const sin = d => Math.sin(d * rad)
+const cos = d => Math.cos(d * rad)
+const asin = x => Math.asin(Math.min(1, Math.max(-1, x))) * DEG
+const acos = x => Math.acos(Math.min(1, Math.max(-1, x))) * DEG
+const atan2 = (y, x) => Math.atan2(y, x) * DEG
+const rev = x => ((x % 360) + 360) % 360
+
+const phaseName = age => {
+  if (age < 22.5 || age >= 337.5) return 'New Moon'
+  if (age < 67.5) return 'Waxing Crescent'
+  if (age < 112.5) return 'First Quarter'
+  if (age < 157.5) return 'Waxing Gibbous'
+  if (age < 202.5) return 'Full Moon'
+  if (age < 247.5) return 'Waning Gibbous'
+  if (age < 292.5) return 'Last Quarter'
+  return 'Waning Crescent'
+}
+
+export const moonPosition = (date, lat, lon) => {
+  const jd = date.getTime() / 86400000 + 2440587.5
+  const d = jd - 2451543.5 // days since 1999-12-31 00:00 UT
+  const UT =
+    date.getUTCHours() +
+    date.getUTCMinutes() / 60 +
+    date.getUTCSeconds() / 3600 +
+    date.getUTCMilliseconds() / 3600000
+
+  // --- Sun (needed for perturbations, sidereal time and the phase) ---
+  const ws = 282.9404 + 4.70935e-5 * d
+  const Ms = rev(356.047 + 0.9856002585 * d)
+  const es = 0.016709 - 1.151e-9 * d
+  const Esun = Ms + es * DEG * sin(Ms) * (1 + es * cos(Ms))
+  const vsun = atan2(Math.sqrt(1 - es * es) * sin(Esun), cos(Esun) - es)
+  const lonsun = rev(vsun + ws)
+  const Lsun = rev(Ms + ws) // sun's mean longitude
+
+  // --- Moon orbital elements ---
+  const N = rev(125.1228 - 0.0529538083 * d)
+  const i = 5.1454
+  const w = rev(318.0634 + 0.1643573223 * d)
+  const a = 60.2666 // Earth radii
+  const e = 0.0549
+  const M = rev(115.3654 + 13.0649929509 * d)
+
+  // Eccentric anomaly (two iterations of Newton's method).
+  let E = M + e * DEG * sin(M) * (1 + e * cos(M))
+  for (let k = 0; k < 2; k++) {
+    E = E - (E - e * DEG * sin(E) - M) / (1 - e * cos(E))
+  }
+
+  const x = a * (cos(E) - e)
+  const y = a * Math.sqrt(1 - e * e) * sin(E)
+  let r = Math.sqrt(x * x + y * y) // Earth radii
+  const v = rev(atan2(y, x))
+
+  // Geocentric ecliptic coordinates.
+  const xeclip = r * (cos(N) * cos(v + w) - sin(N) * sin(v + w) * cos(i))
+  const yeclip = r * (sin(N) * cos(v + w) + cos(N) * sin(v + w) * cos(i))
+  const zeclip = r * sin(v + w) * sin(i)
+
+  let lonecl = rev(atan2(yeclip, xeclip))
+  let latecl = atan2(zeclip, Math.sqrt(xeclip * xeclip + yeclip * yeclip))
+
+  // Main perturbations.
+  const Lm = rev(N + w + M)
+  const D = rev(Lm - Lsun)
+  const F = rev(Lm - N)
+
+  lonecl +=
+    -1.274 * sin(M - 2 * D) +
+    0.658 * sin(2 * D) +
+    -0.186 * sin(Ms) +
+    -0.059 * sin(2 * M - 2 * D) +
+    -0.057 * sin(M - 2 * D + Ms) +
+    0.053 * sin(M + 2 * D) +
+    0.046 * sin(2 * D - Ms) +
+    0.041 * sin(M - Ms) +
+    -0.035 * sin(D) +
+    -0.031 * sin(M + Ms) +
+    -0.015 * sin(2 * F - 2 * D) +
+    0.011 * sin(M - 4 * D)
+  latecl +=
+    -0.173 * sin(F - 2 * D) +
+    -0.055 * sin(M - F - 2 * D) +
+    -0.046 * sin(M + F - 2 * D) +
+    0.033 * sin(F + 2 * D) +
+    0.017 * sin(2 * M + F)
+  r += -0.58 * cos(M - 2 * D) + -0.46 * cos(2 * D)
+  lonecl = rev(lonecl)
+
+  // Ecliptic -> equatorial.
+  const xg = r * cos(lonecl) * cos(latecl)
+  const yg = r * sin(lonecl) * cos(latecl)
+  const zg = r * sin(latecl)
+
+  const ecl = 23.4393 - 3.563e-7 * d
+  const xe = xg
+  const ye = yg * cos(ecl) - zg * sin(ecl)
+  const ze = yg * sin(ecl) + zg * cos(ecl)
+
+  const RA = rev(atan2(ye, xe))
+  const Dec = atan2(ze, Math.sqrt(xe * xe + ye * ye))
+
+  // Equatorial -> horizontal.
+  const GMST0 = rev(Lsun + 180)
+  const LST = rev(GMST0 + UT * 15 + lon)
+  const HA = rev(LST - RA)
+
+  const xh = cos(HA) * cos(Dec)
+  const yh = sin(HA) * cos(Dec)
+  const zh = sin(Dec)
+
+  const xhor = xh * sin(lat) - zh * cos(lat)
+  const yhor = yh
+  const zhor = xh * cos(lat) + zh * sin(lat)
+
+  const azimuth = rev(atan2(yhor, xhor) + 180)
+  const altGeo = atan2(zhor, Math.sqrt(xhor * xhor + yhor * yhor))
+  // Topocentric correction for the Moon's large parallax.
+  const parallax = asin(1 / r)
+  const elevation = altGeo - parallax * cos(altGeo)
+
+  // Phase / illumination.
+  const elong = acos(cos(lonsun - lonecl) * cos(latecl))
+  const illumination = ((1 + cos(180 - elong)) / 2) * 100
+  const age = rev(lonecl - lonsun)
+
+  return {
+    elevation,
+    azimuth,
+    distanceKm: r * 6371,
+    illumination,
+    phase: phaseName(age)
+  }
+}

--- a/app/moon/page.jsx
+++ b/app/moon/page.jsx
@@ -1,0 +1,55 @@
+import Link from 'next/link'
+import { useMDXComponents } from '../../mdx-components'
+import { resolveLocation } from '../geo'
+import LocationTable from '../location-table'
+import DeviceLocationButton from '../sun/device-location-button'
+import { LiveTimeProvider } from '../sun/live'
+import { LiveMoon } from './live'
+
+export const metadata = {
+  title: 'Moon Position',
+  description:
+    'Live phase, illumination, azimuth, elevation, and distance of the moon at your location, updating in real time.'
+}
+
+// Server component so we can read the Vercel-provided location. The time and
+// moon position are then re-rendered live in the browser.
+// `force-dynamic` keeps the location/request data fresh per request.
+export const dynamic = 'force-dynamic'
+
+// The blog theme's content wrapper, so this page gets the same heading, meta
+// bar, container width, and typography as every other page on the site.
+const Wrapper = useMDXComponents().wrapper
+
+export default async function MoonPage() {
+  const now = new Date()
+  const loc = await resolveLocation()
+
+  return (
+    <LiveTimeProvider initialISO={now.toISOString()}>
+      <Wrapper metadata={{ title: 'Moon Position' }}>
+        <h2>Location &amp; Time</h2>
+        <LocationTable loc={loc} />
+
+        <h2>Moon</h2>
+        <p>
+          {loc.usingDeviceLocation
+            ? 'Using your device location.'
+            : 'Using the Vercel IP-based location estimate.'}
+        </p>
+        <LiveMoon lat={loc.effLat} lon={loc.effLon} />
+
+        <DeviceLocationButton />
+
+        <p>
+          <Link href="/sun">Where is the Sun? →</Link>
+        </p>
+
+        <p>
+          Computed from your device location when shared, otherwise the
+          Vercel-provided IP estimate. The time and moon position update live.
+        </p>
+      </Wrapper>
+    </LiveTimeProvider>
+  )
+}

--- a/app/sun/device-location-button.jsx
+++ b/app/sun/device-location-button.jsx
@@ -1,0 +1,47 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+// Asks the browser for the device's geolocation, stashes it in a cookie, then
+// refreshes so the server component can render it next to the Vercel location.
+export default function DeviceLocationButton() {
+  const router = useRouter()
+  const [error, setError] = useState(null)
+  const [loading, setLoading] = useState(false)
+
+  const request = () => {
+    if (!('geolocation' in navigator)) {
+      setError('Geolocation is not supported by this browser.')
+      return
+    }
+    setLoading(true)
+    setError(null)
+    navigator.geolocation.getCurrentPosition(
+      pos => {
+        const { latitude, longitude } = pos.coords
+        const value = encodeURIComponent(
+          JSON.stringify({ lat: latitude, lon: longitude })
+        )
+        // One year, scoped to the whole site.
+        document.cookie = `device-geo=${value}; path=/; max-age=31536000; samesite=lax`
+        router.refresh()
+        setLoading(false)
+      },
+      err => {
+        setError(err.message)
+        setLoading(false)
+      },
+      { enableHighAccuracy: true, timeout: 10000 }
+    )
+  }
+
+  return (
+    <p>
+      <button onClick={request} disabled={loading}>
+        {loading ? 'Locating…' : 'Use my device location'}
+      </button>
+      {error && <span style={{ marginLeft: '.5rem' }}>{error}</span>}
+    </p>
+  )
+}

--- a/app/sun/live.jsx
+++ b/app/sun/live.jsx
@@ -1,0 +1,76 @@
+'use client'
+
+import { createContext, useContext, useEffect, useState } from 'react'
+import { Table } from 'nextra/components'
+import { solarPosition, fmt, compass } from './solar'
+
+// A single ticking clock shared by every live piece on the page, so the
+// displayed time and the sun position are always computed from the same
+// instant. Seeded with the server's render time so the first client render
+// matches the SSR output (no hydration mismatch), then updated every half-phi
+// (the golden ratio conjugate, ~0.618) seconds — i.e. ~0.309 s.
+const NowContext = createContext(new Date(0))
+
+// The golden ratio conjugate, (sqrt(5) - 1) / 2 ≈ 0.6180339887.
+const PHI = (Math.sqrt(5) - 1) / 2
+// Refresh twice as fast as phi seconds, i.e. half the interval (~309 ms).
+const REFRESH_MS = (PHI * 1000) / 2
+
+export function LiveTimeProvider({ initialISO, children }) {
+  const [now, setNow] = useState(() => new Date(initialISO))
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), REFRESH_MS)
+    return () => clearInterval(id)
+  }, [])
+  return <NowContext.Provider value={now}>{children}</NowContext.Provider>
+}
+
+// The shared ticking clock, for live components on other pages (e.g. /moon).
+export function useNow() {
+  return useContext(NowContext)
+}
+
+export function LiveClock() {
+  const now = useContext(NowContext)
+  return <>{now.toISOString()}</>
+}
+
+export function LiveSun({ lat, lon }) {
+  const now = useContext(NowContext)
+
+  if (lat === null || lon === null) {
+    return (
+      <p>
+        No location available. On Vercel this comes from the{' '}
+        <code>x-vercel-ip-latitude</code> / <code>x-vercel-ip-longitude</code>{' '}
+        headers; locally, set the <code>LATITUDE</code> and{' '}
+        <code>LONGITUDE</code> environment variables.
+      </p>
+    )
+  }
+
+  const sun = solarPosition(now, lat, lon)
+  return (
+    <Table>
+      <tbody>
+        <Table.Tr>
+          <Table.Th>Declination</Table.Th>
+          <Table.Td>{fmt(sun.declination)}°</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+          <Table.Th>Azimuth (angle in the sky)</Table.Th>
+          <Table.Td>
+            {fmt(sun.azimuth)}° ({compass(sun.azimuth)})
+          </Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+          <Table.Th>Elevation / inclination above horizon</Table.Th>
+          <Table.Td>
+            {fmt(sun.elevation)}°{' '}
+            {sun.elevation < 0 && <em>(below the horizon)</em>}
+          </Table.Td>
+        </Table.Tr>
+      </tbody>
+    </Table>
+  )
+}

--- a/app/sun/page.jsx
+++ b/app/sun/page.jsx
@@ -1,0 +1,54 @@
+import Link from 'next/link'
+import { useMDXComponents } from '../../mdx-components'
+import { resolveLocation } from '../geo'
+import LocationTable from '../location-table'
+import DeviceLocationButton from './device-location-button'
+import { LiveSun, LiveTimeProvider } from './live'
+
+export const metadata = {
+  title: 'Sun Position',
+  description:
+    'Live azimuth and elevation of the sun at your location, updating in real time.'
+}
+
+// Server component so we can read the Vercel-provided location. The time and
+// sun position are then re-rendered live in the browser.
+// `force-dynamic` keeps the location/request data fresh per request.
+export const dynamic = 'force-dynamic'
+
+// The blog theme's content wrapper, so this page gets the same heading, meta
+// bar, container width, and typography as every other page on the site.
+const Wrapper = useMDXComponents().wrapper
+
+export default async function SunPage() {
+  const now = new Date()
+  const loc = await resolveLocation()
+
+  return (
+    <LiveTimeProvider initialISO={now.toISOString()}>
+      <Wrapper metadata={{ title: 'Sun Position' }}>
+        <h2>Location &amp; Time</h2>
+        <LocationTable loc={loc} />
+
+        <h2>Sun</h2>
+        <p>
+          {loc.usingDeviceLocation
+            ? 'Using your device location.'
+            : 'Using the Vercel IP-based location estimate.'}
+        </p>
+        <LiveSun lat={loc.effLat} lon={loc.effLon} />
+
+        <DeviceLocationButton />
+
+        <p>
+          <Link href="/moon">Where is the Moon? →</Link>
+        </p>
+
+        <p>
+          Computed from your device location when shared, otherwise the
+          Vercel-provided IP estimate. The time and sun position update live.
+        </p>
+      </Wrapper>
+    </LiveTimeProvider>
+  )
+}

--- a/app/sun/solar.js
+++ b/app/sun/solar.js
@@ -1,0 +1,135 @@
+const RAD = Math.PI / 180
+
+// Atmospheric refraction (deg) to add to a geometric solar elevation to get the
+// apparent (observed) elevation. The atmosphere bends sunlight upward, most
+// strongly near the horizon (~0.5°), so the sun stays visible until its
+// geometric centre is roughly 0.83° below the horizon. Same piecewise fit as
+// the NOAA Solar Calculator.
+const refractionCorrection = elevation => {
+  if (elevation > 85) return 0
+  const te = Math.tan(elevation * RAD)
+  let seconds
+  if (elevation > 5) {
+    seconds = 58.1 / te - 0.07 / te ** 3 + 0.000086 / te ** 5
+  } else if (elevation > -0.575) {
+    seconds =
+      1735 +
+      elevation *
+        (-518.2 + elevation * (103.4 + elevation * (-12.79 + elevation * 0.711)))
+  } else {
+    seconds = -20.772 / te
+  }
+  return seconds / 3600 // arc-seconds to degrees
+}
+
+// NOAA solar position algorithm.
+// Ports the equations from the NOAA Solar Calculator spreadsheet.
+export const solarPosition = (date, lat, lon) => {
+  const jd = date.getTime() / 86400000 + 2440587.5
+  const T = (jd - 2451545.0) / 36525.0 // Julian centuries since J2000.0
+
+  const L0 = (((280.46646 + T * (36000.76983 + T * 0.0003032)) % 360) + 360) % 360
+  const M = 357.52911 + T * (35999.05029 - 0.0001537 * T)
+  const e = 0.016708634 - T * (0.000042037 + 0.0000001267 * T)
+
+  const C =
+    Math.sin(M * RAD) * (1.914602 - T * (0.004817 + 0.000014 * T)) +
+    Math.sin(2 * M * RAD) * (0.019993 - 0.000101 * T) +
+    Math.sin(3 * M * RAD) * 0.000289
+
+  const trueLong = L0 + C
+  const omega = 125.04 - 1934.136 * T
+  const lambda = trueLong - 0.00569 - 0.00478 * Math.sin(omega * RAD)
+
+  const seconds = 21.448 - T * (46.815 + T * (0.00059 - T * 0.001813))
+  const e0 = 23 + (26 + seconds / 60) / 60
+  const obliquity = e0 + 0.00256 * Math.cos(omega * RAD)
+
+  const declination =
+    Math.asin(Math.sin(obliquity * RAD) * Math.sin(lambda * RAD)) / RAD
+
+  // Equation of time (minutes)
+  const y = Math.tan((obliquity / 2) * RAD) ** 2
+  const eqTime =
+    (4 *
+      (y * Math.sin(2 * L0 * RAD) -
+        2 * e * Math.sin(M * RAD) +
+        4 * e * y * Math.sin(M * RAD) * Math.cos(2 * L0 * RAD) -
+        0.5 * y * y * Math.sin(4 * L0 * RAD) -
+        1.25 * e * e * Math.sin(2 * M * RAD))) /
+    RAD
+
+  const utcMinutes =
+    date.getUTCHours() * 60 +
+    date.getUTCMinutes() +
+    date.getUTCSeconds() / 60 +
+    date.getUTCMilliseconds() / 60000
+
+  const trueSolarTime = (((utcMinutes + eqTime + 4 * lon) % 1440) + 1440) % 1440
+  let hourAngle = trueSolarTime / 4 - 180
+  if (hourAngle < -180) hourAngle += 360
+
+  const latRad = lat * RAD
+  const declRad = declination * RAD
+  const haRad = hourAngle * RAD
+
+  const cosZenith =
+    Math.sin(latRad) * Math.sin(declRad) +
+    Math.cos(latRad) * Math.cos(declRad) * Math.cos(haRad)
+  const zenith = Math.acos(Math.min(1, Math.max(-1, cosZenith))) / RAD
+
+  // The sun's apparent angular radius (semidiameter). Its distance varies over
+  // the year, so this does too: NOAA's radius vector R (in AU) from the true
+  // anomaly, then the mean semidiameter of 959.63" scaled by 1/R.
+  const trueAnomaly = M + C
+  const R = (1.000001018 * (1 - e * e)) / (1 + e * Math.cos(trueAnomaly * RAD))
+  const semidiameter = 959.63 / 3600 / R // degrees
+
+  // Report the apparent elevation of the sun's *upper limb*: the geometric
+  // angle of the centre, lifted by atmospheric refraction, plus one angular
+  // radius. Sunrise and sunset are defined as the upper limb touching the
+  // horizon, so this reads exactly 0° at those moments.
+  const geometricElevation = 90 - zenith
+  const elevation =
+    geometricElevation +
+    refractionCorrection(geometricElevation) +
+    semidiameter
+
+  const cosAz =
+    (Math.sin(latRad) * Math.cos(zenith * RAD) - Math.sin(declRad)) /
+    (Math.cos(latRad) * Math.sin(zenith * RAD))
+  const az = Math.acos(Math.min(1, Math.max(-1, cosAz))) / RAD
+  const azimuth = hourAngle > 0 ? (az + 180) % 360 : (540 - az) % 360
+
+  return { declination, elevation, azimuth }
+}
+
+// Fixed "en-US" locale so server and client format identically (no hydration
+// mismatch when these values are rendered live in the browser).
+export const fmt = (n, digits = 4) =>
+  n.toLocaleString('en-US', {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits
+  })
+
+export const compass = azimuth => {
+  const dirs = [
+    'N',
+    'NNE',
+    'NE',
+    'ENE',
+    'E',
+    'ESE',
+    'SE',
+    'SSE',
+    'S',
+    'SSW',
+    'SW',
+    'WSW',
+    'W',
+    'WNW',
+    'NW',
+    'NNW'
+  ]
+  return dirs[Math.round(azimuth / 22.5) % 16]
+}


### PR DESCRIPTION
Ports the interactive **Sun** and **Moon** position pages over from the `edencom-sde` project and publishes them as pages on this site.

## What's here
- **`/sun`** — live declination, azimuth, and elevation of the sun (NOAA solar position algorithm).
- **`/moon`** — live phase, illumination, azimuth, elevation, and distance of the moon (Schlyter's low-precision lunar model).
- Both resolve the visitor's location from the Vercel IP headers (`x-vercel-ip-latitude`/`-longitude`), or a more accurate device location the visitor can opt into via a button (stored in a cookie). Time and positions tick live in the browser.

## Fitting the blog
- Rendered through the blog theme's content wrapper (`useMDXComponents().wrapper`), so they get the same `<h1>`, meta bar, container width, and typography as every other page.
- Tables use the theme's `Table` components (dark-mode aware) instead of hardcoded inline styles.
- Added to the navbar via `app/_meta.global.js`.
- The intro/description paragraph sits at the bottom of each page (per request).

## Implementation notes
- These are native App Router routes (`app/sun`, `app/moon`) that coexist with Nextra's `[...mdxPath]` catch-all; explicit routes take precedence. Converted from TS to JS to match the repo.
- Marked `dynamic = 'force-dynamic'` so the per-request location stays fresh.

Verified with `npm run build` (both routes register as dynamic `ƒ`) and by fetching `/sun` and `/moon` from `next start` (HTTP 200, expected content, theme table classes present, navbar links present).

https://claude.ai/code/session_01PqRiaY1Jz1iuuwS8usCjRv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqRiaY1Jz1iuuwS8usCjRv)_