### PR TITLE
Restore blue/purple links and style the device-location button

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,59 @@
+/*
+ * Site-wide overrides on top of `nextra-theme-blog/style.css` (imported just
+ * before this file in app/layout.jsx).
+ */
+
+/*
+ * Link colour. The blog theme renders links in a near-black slate in light
+ * mode and white in dark mode, which makes them read as plain text. Restore a
+ * blue/purple (indigo) link colour, with a lighter shade for dark mode that
+ * stays pleasant on a black background.
+ *
+ * The theme drives every link through these prose custom properties (the whole
+ * site — navbar, content, and footer — is wrapped in a single `.x:prose`
+ * article), so overriding them here recolours links everywhere.
+ */
+.x\:prose {
+  --tw-prose-links: #4f46e5; /* indigo-600, light mode */
+  --tw-prose-invert-links: #818cf8; /* indigo-400, dark mode */
+}
+
+/*
+ * The "Use my device location" control on /sun and /moon. Tailwind's preflight
+ * strips a <button> down to transparent/borderless inherited text, so it looks
+ * like an undecorated link. Give it an actual button appearance.
+ */
+.device-location-button {
+  display: inline-block;
+  margin: 0;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.9rem;
+  font-weight: 600;
+  line-height: 1.2;
+  color: #fff;
+  background-color: #4f46e5; /* indigo-600 */
+  border: 1px solid transparent;
+  border-radius: 6px;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    opacity 0.15s ease;
+}
+
+.device-location-button:hover:not(:disabled) {
+  background-color: #4338ca; /* indigo-700 */
+}
+
+.device-location-button:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.dark .device-location-button {
+  background-color: #6366f1; /* indigo-500 */
+}
+
+.dark .device-location-button:hover:not(:disabled) {
+  background-color: #818cf8; /* indigo-400 */
+}

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -3,6 +3,7 @@ import { Head, Search } from 'nextra/components'
 import { getPageMap } from 'nextra/page-map'
 import Script from 'next/script'
 import 'nextra-theme-blog/style.css'
+import './globals.css'
 
 const SITE_URL = 'https://philihp.com'
 

--- a/app/sun/device-location-button.jsx
+++ b/app/sun/device-location-button.jsx
@@ -38,7 +38,12 @@ export default function DeviceLocationButton() {
 
   return (
     <p>
-      <button onClick={request} disabled={loading}>
+      <button
+        type="button"
+        className="device-location-button"
+        onClick={request}
+        disabled={loading}
+      >
         {loading ? 'Locating…' : 'Use my device location'}
       </button>
       {error && <span style={{ marginLeft: '.5rem' }}>{error}</span>}


### PR DESCRIPTION
## What & why
Two related styling fixes:

### 1. Links are blue/purple again, site-wide
The `nextra-theme-blog` theme renders links in a near-black slate in light mode and white in dark mode, so they read as plain text. This restores a blue/purple link colour:
- **Light mode:** indigo-600 `#4f46e5`
- **Dark mode:** indigo-400 `#818cf8` — a lighter shade that stays pleasant on a black background

The theme routes *every* link (navbar, content, footer) through the prose custom properties `--tw-prose-links` / `--tw-prose-invert-links` on the single `.x:prose` article that wraps the site, so overriding just those two variables recolours links everywhere without touching any other typography.

### 2. The "Use my device location" control looks like a button
Tailwind's preflight strips a bare `<button>` down to transparent background / no border / inherited colour, so the control on `/sun` and `/moon` looked like an undecorated link. It now has a filled indigo button appearance with hover and disabled states, in both light and dark mode.

## Implementation
- New `app/globals.css`, imported in `app/layout.jsx` right after the theme stylesheet so the overrides win at equal specificity.
- `device-location-button.jsx` gains `type="button"` and a `device-location-button` class.

## Verification
- `npm run build` succeeds; the compiled CSS contains the variable overrides (later in the cascade than the theme's, equal specificity → wins) and the button rules, with all other prose variables left intact.
- Served via `next start`: `/sun` returns 200, the button renders with its class, and the stylesheet is linked on the page.

_No headless browser was available in this environment, so the colour values were verified in the compiled CSS rather than via screenshot. Happy to adjust the exact indigo shades if you'd prefer a bluer or more purple tone._

https://claude.ai/code/session_01PqRiaY1Jz1iuuwS8usCjRv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqRiaY1Jz1iuuwS8usCjRv)_