### PR TITLE
Add /tree page: nearby SF street trees sorted by celestial direction

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -57,3 +57,78 @@
 .dark .device-location-button:hover:not(:disabled) {
   background-color: #818cf8; /* indigo-400 */
 }
+
+/*
+ * /tree page: responsive tree-tile grid.
+ * Mobile: each tile is full viewport width (stacked).
+ * Desktop (≥640 px): tiles are inline blocks that wrap to fill available space.
+ */
+.tree-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.tree-tile {
+  box-sizing: border-box;
+  width: 100%;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+@media (min-width: 640px) {
+  .tree-grid {
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: flex-start;
+  }
+
+  .tree-tile {
+    width: auto;
+    min-width: 220px;
+    max-width: 340px;
+  }
+}
+
+.dark .tree-tile {
+  border-color: #334155;
+}
+
+.tree-tile-direction {
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin-bottom: 0.15rem;
+}
+
+.tree-tile-distance {
+  font-size: 0.82rem;
+  color: #64748b;
+  margin-bottom: 0.4rem;
+}
+
+.dark .tree-tile-distance {
+  color: #94a3b8;
+}
+
+.tree-tile-species {
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.tree-tile-details {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.15rem 0.6rem;
+  font-size: 0.8rem;
+  margin: 0;
+}
+
+.tree-tile-details dt {
+  color: #64748b;
+  font-weight: 500;
+}
+
+.dark .tree-tile-details dt {
+  color: #94a3b8;
+}

--- a/app/tree/live.jsx
+++ b/app/tree/live.jsx
@@ -1,0 +1,145 @@
+'use client'
+
+import { useNow } from '../sun/live'
+import { solarPosition, compass } from '../sun/solar'
+import { moonPosition } from '../moon/moon'
+
+const RAD = Math.PI / 180
+
+// Forward bearing (degrees, 0 = N, clockwise) from point 1 to point 2.
+function bearingTo(lat1, lon1, lat2, lon2) {
+  const dLon = (lon2 - lon1) * RAD
+  const x = Math.cos(lat2 * RAD) * Math.sin(dLon)
+  const y =
+    Math.cos(lat1 * RAD) * Math.sin(lat2 * RAD) -
+    Math.sin(lat1 * RAD) * Math.cos(lat2 * RAD) * Math.cos(dLon)
+  return ((Math.atan2(x, y) / RAD) + 360) % 360
+}
+
+// Great-circle distance in metres between two coordinates.
+function distanceTo(lat1, lon1, lat2, lon2) {
+  const dLat = (lat2 - lat1) * RAD
+  const dLon = (lon2 - lon1) * RAD
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1 * RAD) * Math.cos(lat2 * RAD) * Math.sin(dLon / 2) ** 2
+  return 6371000 * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+}
+
+// Format "Fraxinus uhdei :: Shamel Ash: Evergreen Ash" → "Shamel Ash: Evergreen Ash (Fraxinus uhdei)"
+function formatSpecies(qspecies) {
+  if (!qspecies) return 'Unknown species'
+  const sep = qspecies.indexOf(' :: ')
+  if (sep === -1) return qspecies
+  const scientific = qspecies.slice(0, sep)
+  const common = qspecies.slice(sep + 4)
+  return `${common} (${scientific})`
+}
+
+export function LiveTrees({ lat, lon, trees }) {
+  const now = useNow()
+
+  if (lat === null || lon === null) {
+    return (
+      <p>
+        No location available. Share your device location below to see nearby
+        trees.
+      </p>
+    )
+  }
+
+  if (!trees || trees.length === 0) {
+    return (
+      <p>
+        No trees found within 100 m of this location. The dataset covers San
+        Francisco street trees only.
+      </p>
+    )
+  }
+
+  const sun = solarPosition(now, lat, lon)
+  const moon = moonPosition(now, lat, lon)
+
+  let refAzimuth = 0
+  let refLabel = 'North (0°)'
+  if (sun.elevation > 0) {
+    refAzimuth = sun.azimuth
+    refLabel = `Sun (${sun.azimuth.toFixed(1)}° ${compass(sun.azimuth)})`
+  } else if (moon.elevation > 0) {
+    refAzimuth = moon.azimuth
+    refLabel = `Moon (${moon.azimuth.toFixed(1)}° ${compass(moon.azimuth)})`
+  }
+
+  const sorted = trees
+    .filter(t => t.latitude && t.longitude)
+    .map(t => {
+      const tlat = parseFloat(t.latitude)
+      const tlon = parseFloat(t.longitude)
+      const b = bearingTo(lat, lon, tlat, tlon)
+      const d = distanceTo(lat, lon, tlat, tlon)
+      return { ...t, _bearing: b, _distance: d, _angleDiff: (b - refAzimuth + 360) % 360 }
+    })
+    .sort((a, b) => a._angleDiff - b._angleDiff)
+
+  return (
+    <>
+      <p>
+        {sorted.length} tree{sorted.length !== 1 ? 's' : ''} found, sorted
+        clockwise starting from {refLabel}.
+      </p>
+      <div className="tree-grid">
+        {sorted.map(t => (
+          <div key={t.treeid} className="tree-tile">
+            <div className="tree-tile-direction">
+              {compass(t._bearing)} &middot; {t._bearing.toFixed(1)}°
+            </div>
+            <div className="tree-tile-distance">
+              {Math.round(t._distance)} m away
+            </div>
+            <div className="tree-tile-species">
+              {formatSpecies(t.qspecies)}
+            </div>
+            <dl className="tree-tile-details">
+              {t.qaddress && (
+                <>
+                  <dt>Address</dt>
+                  <dd>{t.qaddress}</dd>
+                </>
+              )}
+              {t.qlegalstatus && (
+                <>
+                  <dt>Status</dt>
+                  <dd>{t.qlegalstatus}</dd>
+                </>
+              )}
+              {t.qcaretaker && (
+                <>
+                  <dt>Caretaker</dt>
+                  <dd>{t.qcaretaker}</dd>
+                </>
+              )}
+              {t.qsiteinfo && (
+                <>
+                  <dt>Site</dt>
+                  <dd>{t.qsiteinfo}</dd>
+                </>
+              )}
+              {t.dbh && (
+                <>
+                  <dt>Trunk ⌀</dt>
+                  <dd>{t.dbh}" at breast height</dd>
+                </>
+              )}
+              {t.plantdate && (
+                <>
+                  <dt>Planted</dt>
+                  <dd>{t.plantdate.slice(0, 10)}</dd>
+                </>
+              )}
+            </dl>
+          </div>
+        ))}
+      </div>
+    </>
+  )
+}

--- a/app/tree/page.jsx
+++ b/app/tree/page.jsx
@@ -1,0 +1,67 @@
+import Link from 'next/link'
+import { useMDXComponents } from '../../mdx-components'
+import { resolveLocation } from '../geo'
+import LocationTable from '../location-table'
+import DeviceLocationButton from '../sun/device-location-button'
+import { LiveTimeProvider } from '../sun/live'
+import { LiveTrees } from './live'
+
+export const metadata = {
+  title: 'Nearby Trees',
+  description:
+    'San Francisco street trees within 100 metres of your location, sorted by direction.'
+}
+
+export const dynamic = 'force-dynamic'
+
+const Wrapper = useMDXComponents().wrapper
+
+async function fetchTrees(lat, lon) {
+  if (lat === null || lon === null) return []
+  try {
+    const url =
+      `https://data.sfgov.org/resource/tkzw-k3nq.json` +
+      `?$where=within_circle(location,${lat},${lon},100)&$limit=500`
+    const res = await fetch(url, { cache: 'no-store' })
+    if (!res.ok) return []
+    return await res.json()
+  } catch {
+    return []
+  }
+}
+
+export default async function TreePage() {
+  const now = new Date()
+  const loc = await resolveLocation()
+  const trees = await fetchTrees(loc.effLat, loc.effLon)
+
+  return (
+    <LiveTimeProvider initialISO={now.toISOString()}>
+      <Wrapper metadata={{ title: 'Nearby Trees' }}>
+        <h2>Location &amp; Time</h2>
+        <LocationTable loc={loc} />
+
+        <h2>Trees within 100 m</h2>
+        <p>
+          {loc.usingDeviceLocation
+            ? 'Using your device location.'
+            : 'Using the Vercel IP-based location estimate.'}
+        </p>
+        <LiveTrees lat={loc.effLat} lon={loc.effLon} trees={trees} />
+
+        <DeviceLocationButton />
+
+        <p>
+          <Link href="/sun">Where is the Sun? →</Link>
+        </p>
+        <p>
+          Tree data from the{' '}
+          <a href="https://data.sfgov.org/City-Infrastructure/Street-Tree-List/tkzw-k3nq">
+            SF Department of Public Works Street Tree List
+          </a>
+          .
+        </p>
+      </Wrapper>
+    </LiveTimeProvider>
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1006,9 +1006,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1024,9 +1021,6 @@
       "integrity": "sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1044,9 +1038,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1062,9 +1053,6 @@
       "integrity": "sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
## Summary

- Adds `/tree` route that fetches SF DPW street trees within 100 m of the user's location from `data.sfgov.org/resource/tkzw-k3nq.json`
- Sorts trees clockwise starting from the sun's azimuth (if above the horizon), the moon's azimuth (if above the horizon), or north (0°) as a fallback — updated live every ~309 ms like the sun/moon pages
- Each tree tile shows: compass direction + bearing, distance in metres, species (common + scientific name), address, legal status, caretaker, site info, trunk diameter, and plant date
- Responsive layout: full-width tiles on mobile, inline-block tiles that wrap on desktop (≥ 640 px)
- Reuses `LiveTimeProvider`/`useNow`, `solarPosition`, `moonPosition`, `compass`, `DeviceLocationButton`, and `LocationTable` from existing pages

## Test plan

- [ ] Visit `/tree` — should show trees if IP resolves to SF, or "No trees found" message otherwise
- [ ] Click "Use my device location" in SF — tiles should appear sorted from the sun/moon direction
- [ ] Check mobile view: tiles stack full-width
- [ ] Check desktop view: tiles flow inline as blocks
- [ ] Verify sort reference label updates live (sun → moon → north as time passes)
- [ ] Verify dark mode tile borders and muted text colours

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKLhDh1nTY9hAhNSJu26h5

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKLhDh1nTY9hAhNSJu26h5)_