### PR TITLE
Reduce /tree to 50 m radius, cap at 20 closest trees

### DIFF
--- a/app/tree/live.jsx
+++ b/app/tree/live.jsx
@@ -51,7 +51,7 @@ export function LiveTrees({ lat, lon, trees }) {
   if (!trees || trees.length === 0) {
     return (
       <p>
-        No trees found within 100 m of this location. The dataset covers San
+        No trees found within 50 m of this location. The dataset covers San
         Francisco street trees only.
       </p>
     )
@@ -79,6 +79,8 @@ export function LiveTrees({ lat, lon, trees }) {
       const d = distanceTo(lat, lon, tlat, tlon)
       return { ...t, _bearing: b, _distance: d, _angleDiff: (b - refAzimuth + 360) % 360 }
     })
+    .sort((a, b) => a._distance - b._distance)
+    .slice(0, 20)
     .sort((a, b) => a._angleDiff - b._angleDiff)
 
   return (

--- a/app/tree/page.jsx
+++ b/app/tree/page.jsx
@@ -21,7 +21,7 @@ async function fetchTrees(lat, lon) {
   try {
     const url =
       `https://data.sfgov.org/resource/tkzw-k3nq.json` +
-      `?$where=within_circle(location,${lat},${lon},100)&$limit=500`
+      `?$where=within_circle(location,${lat},${lon},50)&$limit=100`
     const res = await fetch(url, { cache: 'no-store' })
     if (!res.ok) return []
     return await res.json()
@@ -41,7 +41,7 @@ export default async function TreePage() {
         <h2>Location &amp; Time</h2>
         <LocationTable loc={loc} />
 
-        <h2>Trees within 100 m</h2>
+        <h2>Nearest trees within 50 m</h2>
         <p>
           {loc.usingDeviceLocation
             ? 'Using your device location.'


### PR DESCRIPTION
## Summary

- Tightens the SF trees API query from 100 m to 50 m radius
- Caps display at the 20 nearest trees (sorted by distance first, then re-sorted by direction from the reference azimuth)

## Test plan

- [ ] In SF, confirm no more than 20 tiles appear
- [ ] Confirm trees beyond 50 m are excluded
- [ ] Sort order still starts from sun/moon/north direction

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKLhDh1nTY9hAhNSJu26h5

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKLhDh1nTY9hAhNSJu26h5)_