### PR TITLE
Tree page: 15 s location polling, 10-tree cap, no clock; strip "Device" labels

### DIFF
--- a/app/location-table.jsx
+++ b/app/location-table.jsx
@@ -5,7 +5,7 @@ import { fmt } from './sun/solar'
 // The "Location & Time" table shared by the /sun and /moon pages. Shows the
 // Vercel IP estimate until the visitor shares their device location, which is
 // more accurate and replaces it.
-export default function LocationTable({ loc }) {
+export default function LocationTable({ loc, showClock = true }) {
   const { lat, lon, place, deviceLat, deviceLon, devicePlace } = loc
   return (
     <Table>
@@ -31,29 +31,31 @@ export default function LocationTable({ loc }) {
           </>
         )}
         <Table.Tr>
-          <Table.Th>Device latitude (browser)</Table.Th>
+          <Table.Th>Latitude (browser)</Table.Th>
           <Table.Td>
             {deviceLat !== null ? `${fmt(deviceLat, 4)}°` : <em>not shared</em>}
           </Table.Td>
         </Table.Tr>
         <Table.Tr>
-          <Table.Th>Device longitude (browser)</Table.Th>
+          <Table.Th>Longitude (browser)</Table.Th>
           <Table.Td>
             {deviceLon !== null ? `${fmt(deviceLon, 4)}°` : <em>not shared</em>}
           </Table.Td>
         </Table.Tr>
         {loc.usingDeviceLocation && (
           <Table.Tr>
-            <Table.Th>Device city (reverse lookup)</Table.Th>
+            <Table.Th>City (reverse lookup)</Table.Th>
             <Table.Td>{devicePlace ?? <em>unavailable</em>}</Table.Td>
           </Table.Tr>
         )}
-        <Table.Tr>
-          <Table.Th>Time (UTC)</Table.Th>
-          <Table.Td>
-            <LiveClock />
-          </Table.Td>
-        </Table.Tr>
+        {showClock && (
+          <Table.Tr>
+            <Table.Th>Time (UTC)</Table.Th>
+            <Table.Td>
+              <LiveClock />
+            </Table.Td>
+          </Table.Tr>
+        )}
       </tbody>
     </Table>
   )

--- a/app/tree/live.jsx
+++ b/app/tree/live.jsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useEffect, useState } from 'react'
 import { useNow } from '../sun/live'
 import { solarPosition, compass } from '../sun/solar'
 import { moonPosition } from '../moon/moon'
@@ -36,8 +37,44 @@ function formatSpecies(qspecies) {
   return `${common} (${scientific})`
 }
 
-export function LiveTrees({ lat, lon, trees }) {
+async function fetchTreesNear(lat, lon) {
+  const url =
+    `https://data.sfgov.org/resource/tkzw-k3nq.json` +
+    `?$where=within_circle(location,${lat},${lon},50)&$limit=100`
+  const res = await fetch(url)
+  if (!res.ok) return null
+  return await res.json()
+}
+
+export function LiveTrees({ lat: initialLat, lon: initialLon, trees: initialTrees, usingDeviceLocation }) {
   const now = useNow()
+  const [lat, setLat] = useState(initialLat)
+  const [lon, setLon] = useState(initialLon)
+  const [trees, setTrees] = useState(initialTrees)
+
+  // When device location is available, re-query every 15 s for a fresh position
+  // and refetch trees from that new location.
+  useEffect(() => {
+    if (!usingDeviceLocation || typeof navigator === 'undefined' || !navigator.geolocation) return
+
+    const poll = () => {
+      navigator.geolocation.getCurrentPosition(
+        async pos => {
+          const newLat = pos.coords.latitude
+          const newLon = pos.coords.longitude
+          setLat(newLat)
+          setLon(newLon)
+          const newTrees = await fetchTreesNear(newLat, newLon)
+          if (newTrees !== null) setTrees(newTrees)
+        },
+        null,
+        { enableHighAccuracy: true, timeout: 10000 }
+      )
+    }
+
+    const id = setInterval(poll, 15000)
+    return () => clearInterval(id)
+  }, [usingDeviceLocation])
 
   if (lat === null || lon === null) {
     return (
@@ -80,7 +117,7 @@ export function LiveTrees({ lat, lon, trees }) {
       return { ...t, _bearing: b, _distance: d, _angleDiff: (b - refAzimuth + 360) % 360 }
     })
     .sort((a, b) => a._distance - b._distance)
-    .slice(0, 20)
+    .slice(0, 10)
     .sort((a, b) => a._angleDiff - b._angleDiff)
 
   return (

--- a/app/tree/page.jsx
+++ b/app/tree/page.jsx
@@ -39,7 +39,7 @@ export default async function TreePage() {
     <LiveTimeProvider initialISO={now.toISOString()}>
       <Wrapper metadata={{ title: 'Nearby Trees' }}>
         <h2>Location &amp; Time</h2>
-        <LocationTable loc={loc} />
+        <LocationTable loc={loc} showClock={false} />
 
         <h2>Nearest trees within 50 m</h2>
         <p>
@@ -47,7 +47,7 @@ export default async function TreePage() {
             ? 'Using your device location.'
             : 'Using the Vercel IP-based location estimate.'}
         </p>
-        <LiveTrees lat={loc.effLat} lon={loc.effLon} trees={trees} />
+        <LiveTrees lat={loc.effLat} lon={loc.effLon} trees={trees} usingDeviceLocation={loc.usingDeviceLocation} />
 
         <DeviceLocationButton />
 


### PR DESCRIPTION
## Summary

- **15 s location polling**: when device location is available, `LiveTrees` calls `navigator.geolocation.getCurrentPosition` every 15 seconds and re-fetches trees from the SF API at the new position — all client-side, no page reload needed
- **10-tree cap**: nearest-tree slice reduced from 20 to 10
- **No ticking clock on /tree**: `LocationTable` gains a `showClock` prop (default `true`); tree page passes `showClock={false}`
- **Label cleanup**: "Device latitude (browser)" → "Latitude (browser)", "Device longitude (browser)" → "Longitude (browser)", "Device city (reverse lookup)" → "City (reverse lookup)" across /sun and /moon

## Test plan

- [ ] /sun and /moon: confirm labels now read "Latitude (browser)" / "Longitude (browser)" / "City (reverse lookup)", clock still ticks
- [ ] /tree: confirm no UTC clock row in the location table
- [ ] /tree with device location: wait 15 s, confirm lat/lon updates and tree list re-sorts if position changed
- [ ] Confirm still capped at 10 tiles maximum

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKLhDh1nTY9hAhNSJu26h5

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKLhDh1nTY9hAhNSJu26h5)_