### PR TITLE
Toys nav menu, /toys/* URLs, location autocomplete + GPS button

### DIFF
--- a/app/_meta.global.js
+++ b/app/_meta.global.js
@@ -18,14 +18,13 @@ export default {
     type: 'page',
     title: 'Lightning'
   },
-  sun: {
-    type: 'page',
-    title: 'Sun',
-    href: '/sun'
-  },
-  moon: {
-    type: 'page',
-    title: 'Moon',
-    href: '/moon'
+  toys: {
+    type: 'menu',
+    title: 'Toys',
+    items: {
+      sun: { title: 'Sun', href: '/toys/sun' },
+      moon: { title: 'Moon', href: '/toys/moon' },
+      trees: { title: 'Trees', href: '/toys/trees' }
+    }
   }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -58,6 +58,145 @@
   background-color: #818cf8; /* indigo-400 */
 }
 
+/* Location input row (city autocomplete + Set + GPS buttons) */
+.location-input-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+  width: 100%;
+}
+
+.location-input-wrapper {
+  position: relative;
+  flex: 1;
+  min-width: 160px;
+}
+
+.location-input {
+  width: 100%;
+  padding: 0.35rem 0.6rem;
+  font: inherit;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+  box-sizing: border-box;
+}
+
+.location-input:focus {
+  outline: 2px solid #4f46e5;
+  outline-offset: 1px;
+  border-color: #4f46e5;
+}
+
+.dark .location-input {
+  border-color: #475569;
+}
+
+.dark .location-input:focus {
+  outline-color: #818cf8;
+  border-color: #818cf8;
+}
+
+.location-suggestions {
+  position: absolute;
+  top: calc(100% + 2px);
+  left: 0;
+  right: 0;
+  z-index: 50;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  background: #fff;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.dark .location-suggestions {
+  background: #1e293b;
+  border-color: #475569;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+.location-suggestions li {
+  padding: 0.45rem 0.75rem;
+  cursor: pointer;
+  font-size: 0.82rem;
+  line-height: 1.35;
+  border-bottom: 1px solid #f1f5f9;
+}
+
+.location-suggestions li:last-child {
+  border-bottom: none;
+}
+
+.location-suggestions li:hover {
+  background: #f8fafc;
+}
+
+.dark .location-suggestions li {
+  border-color: #334155;
+}
+
+.dark .location-suggestions li:hover {
+  background: #334155;
+}
+
+.location-set-button,
+.location-gps-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.7rem;
+  font: inherit;
+  font-size: 0.9rem;
+  font-weight: 600;
+  line-height: 1.4;
+  color: #fff;
+  background-color: #4f46e5;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background-color 0.15s ease, opacity 0.15s ease;
+}
+
+.location-set-button:hover:not(:disabled),
+.location-gps-button:hover:not(:disabled) {
+  background-color: #4338ca;
+}
+
+.location-set-button:disabled,
+.location-gps-button:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.dark .location-set-button,
+.dark .location-gps-button {
+  background-color: #6366f1;
+}
+
+.dark .location-set-button:hover:not(:disabled),
+.dark .location-gps-button:hover:not(:disabled) {
+  background-color: #818cf8;
+}
+
+.location-gps-error {
+  font-size: 0.82rem;
+  color: #dc2626;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
 /*
  * /tree page: responsive tree-tile grid.
  * Mobile: each tile is full viewport width (stacked).

--- a/app/location-input.jsx
+++ b/app/location-input.jsx
@@ -1,0 +1,161 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+async function nominatimSearch(query) {
+  if (!query || query.length < 3) return []
+  const url =
+    `https://nominatim.openstreetmap.org/search` +
+    `?format=jsonv2&q=${encodeURIComponent(query)}&limit=5&addressdetails=0`
+  const res = await fetch(url)
+  if (!res.ok) return []
+  return await res.json()
+}
+
+function setLocationCookie(lat, lon) {
+  const value = encodeURIComponent(JSON.stringify({ lat, lon }))
+  document.cookie = `device-geo=${value}; path=/; max-age=31536000; samesite=lax`
+}
+
+function GpsIcon({ spinning }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="15"
+      height="15"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      style={spinning ? { animation: 'spin 1s linear infinite' } : undefined}
+    >
+      <path d="M12 8c-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4-1.79-4-4-4zm8.94 3A8.994 8.994 0 0 0 13 3.06V1h-2v2.06A8.994 8.994 0 0 0 3.06 11H1v2h2.06A8.994 8.994 0 0 0 11 20.94V23h2v-2.06A8.994 8.994 0 0 0 20.94 13H23v-2h-2.06zM12 19c-3.87 0-7-3.13-7-7s3.13-7 7-7 7 3.13 7 7-3.13 7-7 7z" />
+    </svg>
+  )
+}
+
+export default function LocationInput({ initialPlace }) {
+  const router = useRouter()
+  const [value, setValue] = useState(initialPlace ?? '')
+  const [suggestions, setSuggestions] = useState([])
+  const [pendingCoords, setPendingCoords] = useState(null)
+  const [isDirty, setIsDirty] = useState(false)
+  const [locating, setLocating] = useState(false)
+  const [gpsError, setGpsError] = useState(null)
+  const debounceRef = useRef(null)
+  const wrapperRef = useRef(null)
+
+  // Close suggestions when clicking outside.
+  useEffect(() => {
+    const handler = e => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target)) {
+        setSuggestions([])
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [])
+
+  const handleChange = e => {
+    const v = e.target.value
+    setValue(v)
+    setIsDirty(true)
+    setPendingCoords(null)
+
+    clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(async () => {
+      setSuggestions(await nominatimSearch(v))
+    }, 300)
+  }
+
+  const selectSuggestion = s => {
+    setValue(s.display_name)
+    setSuggestions([])
+    setPendingCoords({ lat: parseFloat(s.lat), lon: parseFloat(s.lon) })
+    setIsDirty(true)
+  }
+
+  const handleSet = async () => {
+    let coords = pendingCoords
+    if (!coords) {
+      const results = await nominatimSearch(value)
+      if (!results.length) return
+      coords = { lat: parseFloat(results[0].lat), lon: parseFloat(results[0].lon) }
+    }
+    setLocationCookie(coords.lat, coords.lon)
+    setIsDirty(false)
+    setPendingCoords(null)
+    router.refresh()
+  }
+
+  const handleGps = () => {
+    if (!('geolocation' in navigator)) {
+      setGpsError('Geolocation not supported.')
+      return
+    }
+    setLocating(true)
+    setGpsError(null)
+    navigator.geolocation.getCurrentPosition(
+      pos => {
+        setLocationCookie(pos.coords.latitude, pos.coords.longitude)
+        setLocating(false)
+        router.refresh()
+      },
+      err => {
+        setGpsError(err.message)
+        setLocating(false)
+      },
+      { enableHighAccuracy: true, timeout: 10000 }
+    )
+  }
+
+  return (
+    <span className="location-input-row">
+      <span className="location-input-wrapper" ref={wrapperRef}>
+        <input
+          type="text"
+          className="location-input"
+          value={value}
+          onChange={handleChange}
+          placeholder="City, state, or address…"
+          aria-label="Location"
+          aria-autocomplete="list"
+        />
+        {suggestions.length > 0 && (
+          <ul className="location-suggestions" role="listbox">
+            {suggestions.map((s, i) => (
+              <li
+                key={i}
+                role="option"
+                aria-selected={false}
+                onMouseDown={() => selectSuggestion(s)}
+              >
+                {s.display_name}
+              </li>
+            ))}
+          </ul>
+        )}
+      </span>
+      <button
+        type="button"
+        className="location-set-button"
+        onClick={handleSet}
+        disabled={!isDirty}
+      >
+        Set
+      </button>
+      <button
+        type="button"
+        className="location-gps-button"
+        onClick={handleGps}
+        disabled={locating}
+        title={locating ? 'Locating…' : 'Use my device location'}
+      >
+        <GpsIcon spinning={locating} />
+      </button>
+      {gpsError && (
+        <span className="location-gps-error">{gpsError}</span>
+      )}
+    </span>
+  )
+}

--- a/app/location-table.jsx
+++ b/app/location-table.jsx
@@ -1,10 +1,8 @@
 import { Table } from 'nextra/components'
 import { LiveClock } from './sun/live'
 import { fmt } from './sun/solar'
+import LocationInput from './location-input'
 
-// The "Location & Time" table shared by the /sun and /moon pages. Shows the
-// Vercel IP estimate until the visitor shares their device location, which is
-// more accurate and replaces it.
 export default function LocationTable({ loc, showClock = true }) {
   const { lat, lon, place, deviceLat, deviceLon, devicePlace } = loc
   return (
@@ -24,10 +22,6 @@ export default function LocationTable({ loc, showClock = true }) {
                 {lon !== null ? `${fmt(lon, 4)}°` : <em>unavailable</em>}
               </Table.Td>
             </Table.Tr>
-            <Table.Tr>
-              <Table.Th>Nearest city / state / country</Table.Th>
-              <Table.Td>{place !== '' ? place : <em>unavailable</em>}</Table.Td>
-            </Table.Tr>
           </>
         )}
         <Table.Tr>
@@ -42,12 +36,14 @@ export default function LocationTable({ loc, showClock = true }) {
             {deviceLon !== null ? `${fmt(deviceLon, 4)}°` : <em>not shared</em>}
           </Table.Td>
         </Table.Tr>
-        {loc.usingDeviceLocation && (
-          <Table.Tr>
-            <Table.Th>City (reverse lookup)</Table.Th>
-            <Table.Td>{devicePlace ?? <em>unavailable</em>}</Table.Td>
-          </Table.Tr>
-        )}
+        <Table.Tr>
+          <Table.Th>Location</Table.Th>
+          <Table.Td>
+            <LocationInput
+              initialPlace={devicePlace ?? place ?? ''}
+            />
+          </Table.Td>
+        </Table.Tr>
         {showClock && (
           <Table.Tr>
             <Table.Th>Time (UTC)</Table.Th>

--- a/app/toys/moon/page.jsx
+++ b/app/toys/moon/page.jsx
@@ -1,10 +1,9 @@
 import Link from 'next/link'
-import { useMDXComponents } from '../../mdx-components'
-import { resolveLocation } from '../geo'
-import LocationTable from '../location-table'
-import DeviceLocationButton from '../sun/device-location-button'
-import { LiveTimeProvider } from '../sun/live'
-import { LiveMoon } from './live'
+import { useMDXComponents } from '../../../mdx-components'
+import { resolveLocation } from '../../geo'
+import LocationTable from '../../location-table'
+import { LiveTimeProvider } from '../../sun/live'
+import { LiveMoon } from '../../moon/live'
 
 export const metadata = {
   title: 'Moon Position',
@@ -12,13 +11,8 @@ export const metadata = {
     'Live phase, illumination, azimuth, elevation, and distance of the moon at your location, updating in real time.'
 }
 
-// Server component so we can read the Vercel-provided location. The time and
-// moon position are then re-rendered live in the browser.
-// `force-dynamic` keeps the location/request data fresh per request.
 export const dynamic = 'force-dynamic'
 
-// The blog theme's content wrapper, so this page gets the same heading, meta
-// bar, container width, and typography as every other page on the site.
 const Wrapper = useMDXComponents().wrapper
 
 export default async function MoonPage() {
@@ -39,10 +33,11 @@ export default async function MoonPage() {
         </p>
         <LiveMoon lat={loc.effLat} lon={loc.effLon} />
 
-        <DeviceLocationButton />
-
         <p>
-          <Link href="/sun">Where is the Sun? →</Link>
+          <Link href="/toys/sun">Where is the Sun? →</Link>
+        </p>
+        <p>
+          <Link href="/toys/trees">Nearby trees →</Link>
         </p>
 
         <p>

--- a/app/toys/sun/page.jsx
+++ b/app/toys/sun/page.jsx
@@ -1,9 +1,8 @@
 import Link from 'next/link'
-import { useMDXComponents } from '../../mdx-components'
-import { resolveLocation } from '../geo'
-import LocationTable from '../location-table'
-import DeviceLocationButton from './device-location-button'
-import { LiveSun, LiveTimeProvider } from './live'
+import { useMDXComponents } from '../../../mdx-components'
+import { resolveLocation } from '../../geo'
+import LocationTable from '../../location-table'
+import { LiveSun, LiveTimeProvider } from '../../sun/live'
 
 export const metadata = {
   title: 'Sun Position',
@@ -11,13 +10,8 @@ export const metadata = {
     'Live azimuth and elevation of the sun at your location, updating in real time.'
 }
 
-// Server component so we can read the Vercel-provided location. The time and
-// sun position are then re-rendered live in the browser.
-// `force-dynamic` keeps the location/request data fresh per request.
 export const dynamic = 'force-dynamic'
 
-// The blog theme's content wrapper, so this page gets the same heading, meta
-// bar, container width, and typography as every other page on the site.
 const Wrapper = useMDXComponents().wrapper
 
 export default async function SunPage() {
@@ -38,10 +32,11 @@ export default async function SunPage() {
         </p>
         <LiveSun lat={loc.effLat} lon={loc.effLon} />
 
-        <DeviceLocationButton />
-
         <p>
-          <Link href="/moon">Where is the Moon? →</Link>
+          <Link href="/toys/moon">Where is the Moon? →</Link>
+        </p>
+        <p>
+          <Link href="/toys/trees">Nearby trees →</Link>
         </p>
 
         <p>

--- a/app/toys/trees/page.jsx
+++ b/app/toys/trees/page.jsx
@@ -1,15 +1,14 @@
 import Link from 'next/link'
-import { useMDXComponents } from '../../mdx-components'
-import { resolveLocation } from '../geo'
-import LocationTable from '../location-table'
-import DeviceLocationButton from '../sun/device-location-button'
-import { LiveTimeProvider } from '../sun/live'
-import { LiveTrees } from './live'
+import { useMDXComponents } from '../../../mdx-components'
+import { resolveLocation } from '../../geo'
+import LocationTable from '../../location-table'
+import { LiveTimeProvider } from '../../sun/live'
+import { LiveTrees } from '../../tree/live'
 
 export const metadata = {
   title: 'Nearby Trees',
   description:
-    'San Francisco street trees within 100 metres of your location, sorted by direction.'
+    'San Francisco street trees within 50 metres of your location, sorted by direction.'
 }
 
 export const dynamic = 'force-dynamic'
@@ -21,7 +20,7 @@ async function fetchTrees(lat, lon) {
   try {
     const url =
       `https://data.sfgov.org/resource/tkzw-k3nq.json` +
-      `?$where=within_circle(location,${lat},${lon},50)&$limit=100`
+      `?$where=within_circle(location,${lat},${lon},50)&$limit=200`
     const res = await fetch(url, { cache: 'no-store' })
     if (!res.ok) return []
     return await res.json()
@@ -30,7 +29,7 @@ async function fetchTrees(lat, lon) {
   }
 }
 
-export default async function TreePage() {
+export default async function TreesPage() {
   const now = new Date()
   const loc = await resolveLocation()
   const trees = await fetchTrees(loc.effLat, loc.effLon)
@@ -47,12 +46,15 @@ export default async function TreePage() {
             ? 'Using your device location.'
             : 'Using the Vercel IP-based location estimate.'}
         </p>
-        <LiveTrees lat={loc.effLat} lon={loc.effLon} trees={trees} usingDeviceLocation={loc.usingDeviceLocation} />
-
-        <DeviceLocationButton />
+        <LiveTrees
+          lat={loc.effLat}
+          lon={loc.effLon}
+          trees={trees}
+          usingDeviceLocation={loc.usingDeviceLocation}
+        />
 
         <p>
-          <Link href="/sun">Where is the Sun? →</Link>
+          <Link href="/toys/sun">Where is the Sun? →</Link>
         </p>
         <p>
           Tree data from the{' '}

--- a/redirects.json
+++ b/redirects.json
@@ -1,4 +1,7 @@
 [
+  { "source": "/sun",  "destination": "/toys/sun",   "permanent": true },
+  { "source": "/moon", "destination": "/toys/moon",  "permanent": true },
+  { "source": "/tree", "destination": "/toys/trees", "permanent": true },
   {
     "source": "/blog/2008/using-wget-with-http-get-parameters",
     "destination": "/2008/using-wget-with-http-get-parameters.html",


### PR DESCRIPTION
## Summary

### URL reorganization
- Pages moved: `/sun` → `/toys/sun`, `/moon` → `/toys/moon`, `/tree` → `/toys/trees`
- Permanent 301 redirects added to `redirects.json` for all three old URLs
- Helper files (`live.jsx`, `solar.js`, `moon.js`, `device-location-button.jsx`) stay in place; only `page.jsx` files moved

### Nav
- `_meta.global.js`: `sun` and `moon` entries replaced with a single `toys` entry (`type: 'menu'`) containing Sun / Moon / Trees items — renders as a dropdown in the Nextra navbar

### Location UI overhaul (`LocationInput`)
- New `app/location-input.jsx` client component replaces the static city label and the standalone `DeviceLocationButton`
- **Autocomplete**: Nominatim search (300 ms debounce, up to 5 suggestions) as the user types — no API key needed, CORS-friendly, consistent with the reverse-geocode already in `geo.js`
- **Set button**: disabled until the input changes; on click, uses pending coords from suggestion selection (or geocodes fresh) → writes `device-geo` cookie → `router.refresh()`
- **GPS icon button**: crosshair SVG, spins while locating, same cookie + refresh flow as before
- `LocationTable` now renders `LocationInput` in a "Location" row; `showClock` prop preserved; standalone `DeviceLocationButton` removed from all toy pages

## Test plan
- [ ] `/sun`, `/moon`, `/tree` redirect permanently to `/toys/*`
- [ ] "Toys" appears in navbar as a dropdown with Sun / Moon / Trees items
- [ ] Typing a city in the Location field shows autocomplete suggestions
- [ ] Clicking a suggestion populates the field and enables Set
- [ ] Clicking Set updates position (check lat/lon rows update after refresh)
- [ ] GPS button acquires device location and refreshes
- [ ] Spinning animation on GPS icon while locating
- [ ] Dark mode: input border, suggestions dropdown, buttons all look correct
- [ ] `/toys/trees` still shows no clock; `/toys/sun` and `/toys/moon` still show UTC clock

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKLhDh1nTY9hAhNSJu26h5

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKLhDh1nTY9hAhNSJu26h5)_