### PR TITLE
Toys overview page, sub-nav, Blog rename, theme cookie, GPS text update

### DIFF
--- a/app/_meta.global.js
+++ b/app/_meta.global.js
@@ -3,7 +3,7 @@
 export default {
   index: {
     type: 'page',
-    title: 'philihp',
+    title: 'Blog',
     href: '/'
   },
   about: {
@@ -22,6 +22,7 @@ export default {
     type: 'menu',
     title: 'Toys',
     items: {
+      overview: { title: 'Overview', href: '/toys' },
       sun: { title: 'Sun', href: '/toys/sun' },
       moon: { title: 'Moon', href: '/toys/moon' },
       trees: { title: 'Trees', href: '/toys/trees' }

--- a/app/globals.css
+++ b/app/globals.css
@@ -197,6 +197,94 @@
   to { transform: rotate(360deg); }
 }
 
+/* /toys root page: large icon grid */
+.toys-grid {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 3rem 5rem;
+  padding: 3rem 0;
+}
+
+.toy-card-link {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  text-decoration: none !important;
+  color: inherit;
+  transition: transform 0.15s ease, opacity 0.15s ease;
+}
+
+.toy-card-link:hover {
+  opacity: 0.75;
+  transform: scale(1.04);
+}
+
+.toy-card-icon {
+  width: 180px;
+  height: 180px;
+}
+
+.toy-card-label {
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
+/* Toys sub-page nav bar */
+.toy-nav {
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.5rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.dark .toy-nav {
+  border-color: #334155;
+}
+
+.toy-nav-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.65rem;
+  border-radius: 6px;
+  text-decoration: none !important;
+  font-size: 0.88rem;
+  font-weight: 500;
+  color: #64748b;
+  transition: background 0.1s ease, color 0.1s ease;
+}
+
+.toy-nav-link:hover {
+  background: #f1f5f9;
+  color: #1e293b;
+}
+
+.toy-nav-link[aria-current="page"] {
+  background: #ede9fe;
+  color: #4f46e5;
+  font-weight: 700;
+}
+
+.dark .toy-nav-link:hover {
+  background: #1e293b;
+  color: #e2e8f0;
+}
+
+.dark .toy-nav-link[aria-current="page"] {
+  background: #312e81;
+  color: #818cf8;
+}
+
+.toy-nav-icon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
 /*
  * /tree page: responsive tree-tile grid.
  * Mobile: each tile is full viewport width (stacked).

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -35,6 +35,15 @@ export default async function RootLayout({ children }) {
   return (
     <html lang="en" suppressHydrationWarning>
       <Head />
+      <Script id="theme-cookie-sync" strategy="beforeInteractive">{`(function(){
+  var KEY='theme',COOKIE='x-theme',MAX=3600;
+  function read(){var m=document.cookie.match(/(?:^|;\\s*)x-theme=([^;]*)/);return m?decodeURIComponent(m[1]):null;}
+  function write(v){document.cookie=COOKIE+'='+encodeURIComponent(v)+'; path=/; max-age='+MAX+'; samesite=lax';}
+  var saved=read();
+  if(saved){try{localStorage.setItem(KEY,saved);}catch(e){}write(saved);}
+  var _set=Storage.prototype.setItem;
+  Storage.prototype.setItem=function(k,v){_set.call(this,k,v);if(this===localStorage&&k===KEY)write(v);};
+})();`}</Script>
       <Script id="in-app-browser-redirect" strategy="beforeInteractive">
         {`(function () {
   // Redirect visitors arriving from the Instagram or Facebook in-app

--- a/app/location-input.jsx
+++ b/app/location-input.jsx
@@ -96,8 +96,22 @@ export default function LocationInput({ initialPlace }) {
     setLocating(true)
     setGpsError(null)
     navigator.geolocation.getCurrentPosition(
-      pos => {
-        setLocationCookie(pos.coords.latitude, pos.coords.longitude)
+      async pos => {
+        const { latitude, longitude } = pos.coords
+        // Reverse geocode to update the text box immediately.
+        try {
+          const res = await fetch(
+            `https://nominatim.openstreetmap.org/reverse?format=jsonv2&lat=${latitude}&lon=${longitude}&zoom=10`
+          )
+          if (res.ok) {
+            const data = await res.json()
+            const a = data.address ?? {}
+            const city = a.city ?? a.town ?? a.village ?? a.hamlet ?? a.county ?? a.suburb
+            const parts = [city, a.state, a.country_code?.toUpperCase() ?? a.country].filter(Boolean)
+            if (parts.length > 0) setValue(parts.join(', '))
+          }
+        } catch {}
+        setLocationCookie(latitude, longitude)
         setLocating(false)
         router.refresh()
       },

--- a/app/toys/icons.jsx
+++ b/app/toys/icons.jsx
@@ -1,0 +1,39 @@
+// Shared SVG icons for the Toys section.
+// viewBox="0 0 100 100", fill/stroke="currentColor" → inherit colour, scale via CSS.
+
+export function SunIcon({ className }) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" className={className} aria-hidden="true">
+      <circle cx="50" cy="50" r="17" fill="currentColor" />
+      <line x1="50"   y1="24"   x2="50"   y2="6"    stroke="currentColor" strokeWidth="6" strokeLinecap="round" />
+      <line x1="68.4" y1="31.6" x2="81.1" y2="18.9" stroke="currentColor" strokeWidth="6" strokeLinecap="round" />
+      <line x1="76"   y1="50"   x2="94"   y2="50"   stroke="currentColor" strokeWidth="6" strokeLinecap="round" />
+      <line x1="68.4" y1="68.4" x2="81.1" y2="81.1" stroke="currentColor" strokeWidth="6" strokeLinecap="round" />
+      <line x1="50"   y1="76"   x2="50"   y2="94"   stroke="currentColor" strokeWidth="6" strokeLinecap="round" />
+      <line x1="31.6" y1="68.4" x2="18.9" y2="81.1" stroke="currentColor" strokeWidth="6" strokeLinecap="round" />
+      <line x1="24"   y1="50"   x2="6"    y2="50"   stroke="currentColor" strokeWidth="6" strokeLinecap="round" />
+      <line x1="31.6" y1="31.6" x2="18.9" y2="18.9" stroke="currentColor" strokeWidth="6" strokeLinecap="round" />
+    </svg>
+  )
+}
+
+export function MoonIcon({ className }) {
+  // Crescent: outer arc of lit circle (r=32, centre 50,50) minus shadow circle (r=28, centre 63,50).
+  // Intersection points ≈ (65.7, 22.1) and (65.7, 77.9).
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" className={className} aria-hidden="true">
+      <path d="M 65.7 22.1 A 32 32 0 1 0 65.7 77.9 A 28 28 0 0 1 65.7 22.1 Z" fill="currentColor" />
+    </svg>
+  )
+}
+
+export function TreeIcon({ className }) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" className={className} aria-hidden="true">
+      <rect x="44" y="76" width="12" height="20" rx="2" fill="currentColor" />
+      <polygon points="50,42 12,78 88,78" fill="currentColor" />
+      <polygon points="50,24 20,58 80,58" fill="currentColor" />
+      <polygon points="50,6  28,40 72,40" fill="currentColor" />
+    </svg>
+  )
+}

--- a/app/toys/moon/page.jsx
+++ b/app/toys/moon/page.jsx
@@ -4,6 +4,7 @@ import { resolveLocation } from '../../geo'
 import LocationTable from '../../location-table'
 import { LiveTimeProvider } from '../../sun/live'
 import { LiveMoon } from '../../moon/live'
+import ToyNav from '../toy-nav'
 
 export const metadata = {
   title: 'Moon Position',
@@ -22,6 +23,7 @@ export default async function MoonPage() {
   return (
     <LiveTimeProvider initialISO={now.toISOString()}>
       <Wrapper metadata={{ title: 'Moon Position' }}>
+        <ToyNav />
         <h2>Location &amp; Time</h2>
         <LocationTable loc={loc} />
 

--- a/app/toys/page.jsx
+++ b/app/toys/page.jsx
@@ -1,0 +1,31 @@
+import Link from 'next/link'
+import { useMDXComponents } from '../../mdx-components'
+import { SunIcon, MoonIcon, TreeIcon } from './icons'
+
+export const metadata = {
+  title: 'Toys',
+  description: 'Interactive tools: live sun & moon position and nearby trees.'
+}
+
+const Wrapper = useMDXComponents().wrapper
+
+const TOYS = [
+  { href: '/toys/sun',   label: 'Sun',   Icon: SunIcon  },
+  { href: '/toys/moon',  label: 'Moon',  Icon: MoonIcon },
+  { href: '/toys/trees', label: 'Trees', Icon: TreeIcon  },
+]
+
+export default function ToysPage() {
+  return (
+    <Wrapper metadata={{ title: 'Toys' }}>
+      <div className="toys-grid">
+        {TOYS.map(({ href, label, Icon }) => (
+          <Link key={href} href={href} className="toy-card-link">
+            <Icon className="toy-card-icon" />
+            <span className="toy-card-label">{label}</span>
+          </Link>
+        ))}
+      </div>
+    </Wrapper>
+  )
+}

--- a/app/toys/sun/page.jsx
+++ b/app/toys/sun/page.jsx
@@ -3,6 +3,7 @@ import { useMDXComponents } from '../../../mdx-components'
 import { resolveLocation } from '../../geo'
 import LocationTable from '../../location-table'
 import { LiveSun, LiveTimeProvider } from '../../sun/live'
+import ToyNav from '../toy-nav'
 
 export const metadata = {
   title: 'Sun Position',
@@ -21,6 +22,7 @@ export default async function SunPage() {
   return (
     <LiveTimeProvider initialISO={now.toISOString()}>
       <Wrapper metadata={{ title: 'Sun Position' }}>
+        <ToyNav />
         <h2>Location &amp; Time</h2>
         <LocationTable loc={loc} />
 

--- a/app/toys/toy-nav.jsx
+++ b/app/toys/toy-nav.jsx
@@ -1,0 +1,30 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { SunIcon, MoonIcon, TreeIcon } from './icons'
+
+const TOYS = [
+  { href: '/toys/sun',   label: 'Sun',   Icon: SunIcon  },
+  { href: '/toys/moon',  label: 'Moon',  Icon: MoonIcon },
+  { href: '/toys/trees', label: 'Trees', Icon: TreeIcon  },
+]
+
+export default function ToyNav() {
+  const pathname = usePathname()
+  return (
+    <nav className="toy-nav" aria-label="Toys">
+      {TOYS.map(({ href, label, Icon }) => (
+        <Link
+          key={href}
+          href={href}
+          className="toy-nav-link"
+          aria-current={pathname === href ? 'page' : undefined}
+        >
+          <Icon className="toy-nav-icon" />
+          {label}
+        </Link>
+      ))}
+    </nav>
+  )
+}

--- a/app/toys/trees/page.jsx
+++ b/app/toys/trees/page.jsx
@@ -4,6 +4,7 @@ import { resolveLocation } from '../../geo'
 import LocationTable from '../../location-table'
 import { LiveTimeProvider } from '../../sun/live'
 import { LiveTrees } from '../../tree/live'
+import ToyNav from '../toy-nav'
 
 export const metadata = {
   title: 'Nearby Trees',
@@ -37,6 +38,7 @@ export default async function TreesPage() {
   return (
     <LiveTimeProvider initialISO={now.toISOString()}>
       <Wrapper metadata={{ title: 'Nearby Trees' }}>
+        <ToyNav />
         <h2>Location &amp; Time</h2>
         <LocationTable loc={loc} showClock={false} />
 


### PR DESCRIPTION
## Summary

- **`/toys` overview page**: three large SVG icons (Sun ☀️, Moon 🌙, Tree 🌲) each linking to their respective page
- **Toys sub-nav**: a small icon + label nav bar appears at the top of `/toys/sun`, `/toys/moon`, and `/toys/trees`; active page is highlighted
- **"Overview" dropdown entry**: Toys navbar dropdown now includes an Overview link to `/toys`
- **"Blog" rename**: the "philihp" navbar item is now labelled "Blog"
- **Theme cookie (1 hr)**: a `beforeInteractive` script syncs `next-themes` localStorage to an `x-theme` cookie with 1-hour `max-age`; on every page load the cookie is re-read (applying the saved theme) and re-written (bumping the expiry); localStorage writes are intercepted so future theme changes stay in sync
- **GPS → text box**: clicking the GPS button now reverse-geocodes the coordinates via Nominatim and updates the location input field with the city/state/country before the page refreshes

## Test plan

- [ ] Visit `/toys` — three large icons visible, each links to the correct page
- [ ] On `/toys/sun`, `/toys/moon`, `/toys/trees` — nav bar shows all three icons, current page highlighted
- [ ] Navbar shows "Blog" (not "philihp") and Toys dropdown has "Overview" entry
- [ ] Toggle dark/light mode, close and reopen tab within 1 hour — theme persists; wait > 1 hour — theme resets to system default
- [ ] Click GPS button on a toys page — text box updates to city/state/country before page refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKLhDh1nTY9hAhNSJu26h5

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKLhDh1nTY9hAhNSJu26h5)_