### PR TITLE
Sort nearby trees by distance (closest first)

### DIFF
--- a/app/toys/trees/page.jsx
+++ b/app/toys/trees/page.jsx
@@ -2,14 +2,13 @@ import Link from 'next/link'
 import { useMDXComponents } from '../../../mdx-components'
 import { resolveLocation } from '../../geo'
 import LocationTable from '../../location-table'
-import { LiveTimeProvider } from '../../sun/live'
 import { LiveTrees } from '../../tree/live'
 import ToyNav from '../toy-nav'
 
 export const metadata = {
   title: 'Nearby Trees',
   description:
-    'San Francisco street trees within 50 metres of your location, sorted by direction.'
+    'San Francisco street trees within 50 metres of your location, sorted by distance.'
 }
 
 export const dynamic = 'force-dynamic'
@@ -31,41 +30,38 @@ async function fetchTrees(lat, lon) {
 }
 
 export default async function TreesPage() {
-  const now = new Date()
   const loc = await resolveLocation()
   const trees = await fetchTrees(loc.effLat, loc.effLon)
 
   return (
-    <LiveTimeProvider initialISO={now.toISOString()}>
-      <Wrapper metadata={{ title: 'Nearby Trees' }}>
-        <ToyNav />
-        <h2>Location &amp; Time</h2>
-        <LocationTable loc={loc} showClock={false} />
+    <Wrapper metadata={{ title: 'Nearby Trees' }}>
+      <ToyNav />
+      <h2>Location &amp; Time</h2>
+      <LocationTable loc={loc} showClock={false} />
 
-        <h2>Nearest trees within 50 m</h2>
-        <p>
-          {loc.usingDeviceLocation
-            ? 'Using your device location.'
-            : 'Using the Vercel IP-based location estimate.'}
-        </p>
-        <LiveTrees
-          lat={loc.effLat}
-          lon={loc.effLon}
-          trees={trees}
-          usingDeviceLocation={loc.usingDeviceLocation}
-        />
+      <h2>Nearest trees within 50 m</h2>
+      <p>
+        {loc.usingDeviceLocation
+          ? 'Using your device location.'
+          : 'Using the Vercel IP-based location estimate.'}
+      </p>
+      <LiveTrees
+        lat={loc.effLat}
+        lon={loc.effLon}
+        trees={trees}
+        usingDeviceLocation={loc.usingDeviceLocation}
+      />
 
-        <p>
-          <Link href="/toys/sun">Where is the Sun? →</Link>
-        </p>
-        <p>
-          Tree data from the{' '}
-          <a href="https://data.sfgov.org/City-Infrastructure/Street-Tree-List/tkzw-k3nq">
-            SF Department of Public Works Street Tree List
-          </a>
-          .
-        </p>
-      </Wrapper>
-    </LiveTimeProvider>
+      <p>
+        <Link href="/toys/sun">Where is the Sun? →</Link>
+      </p>
+      <p>
+        Tree data from the{' '}
+        <a href="https://data.sfgov.org/City-Infrastructure/Street-Tree-List/tkzw-k3nq">
+          SF Department of Public Works Street Tree List
+        </a>
+        .
+      </p>
+    </Wrapper>
   )
 }

--- a/app/tree/live.jsx
+++ b/app/tree/live.jsx
@@ -1,9 +1,7 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
-import { useNow } from '../sun/live'
-import { solarPosition, compass } from '../sun/solar'
-import { moonPosition } from '../moon/moon'
+import { compass } from '../sun/solar'
 
 const RAD = Math.PI / 180
 
@@ -74,7 +72,6 @@ function TreeImage({ qspecies }) {
 }
 
 export function LiveTrees({ lat: initialLat, lon: initialLon, trees: initialTrees, usingDeviceLocation }) {
-  const now = useNow()
   const [lat, setLat] = useState(initialLat)
   const [lon, setLon] = useState(initialLon)
   const [trees, setTrees] = useState(initialTrees)
@@ -143,19 +140,6 @@ export function LiveTrees({ lat: initialLat, lon: initialLon, trees: initialTree
     )
   }
 
-  const sun = solarPosition(now, lat, lon)
-  const moon = moonPosition(now, lat, lon)
-
-  let refAzimuth = 0
-  let refLabel = 'North (0°)'
-  if (sun.elevation > 0) {
-    refAzimuth = sun.azimuth
-    refLabel = `Sun (${sun.azimuth.toFixed(1)}° ${compass(sun.azimuth)})`
-  } else if (moon.elevation > 0) {
-    refAzimuth = moon.azimuth
-    refLabel = `Moon (${moon.azimuth.toFixed(1)}° ${compass(moon.azimuth)})`
-  }
-
   const sorted = trees
     .filter(t => t.latitude && t.longitude)
     .map(t => {
@@ -163,17 +147,16 @@ export function LiveTrees({ lat: initialLat, lon: initialLon, trees: initialTree
       const tlon = parseFloat(t.longitude)
       const b = bearingTo(lat, lon, tlat, tlon)
       const d = distanceTo(lat, lon, tlat, tlon)
-      return { ...t, _bearing: b, _distance: d, _angleDiff: (b - refAzimuth + 360) % 360 }
+      return { ...t, _bearing: b, _distance: d }
     })
     .sort((a, b) => a._distance - b._distance)
     .slice(0, 20)
-    .sort((a, b) => a._angleDiff - b._angleDiff)
 
   return (
     <>
       <p>
-        {sorted.length} tree{sorted.length !== 1 ? 's' : ''} found, sorted
-        clockwise starting from {refLabel}.
+        {sorted.length} tree{sorted.length !== 1 ? 's' : ''} found, sorted by
+        distance.
       </p>
       <div className="tree-grid">
         {sorted.map(t => (


### PR DESCRIPTION
## Summary

- Trees are now ordered purely by great-circle distance from the user's position (closest first)
- Removes the previous sun/moon azimuth-based angular sort
- Cleans up unused imports (`LiveTimeProvider`, `useNow`, `solarPosition`, `moonPosition`) from the trees page and live component

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKLhDh1nTY9hAhNSJu26h5

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKLhDh1nTY9hAhNSJu26h5)_