### PR TITLE
Replace location text input with plain text + GPS button only

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -19,136 +19,9 @@
 }
 
 /*
- * The "Use my device location" control on /sun and /moon. Tailwind's preflight
- * strips a <button> down to transparent/borderless inherited text, so it looks
- * like an undecorated link. Give it an actual button appearance.
+ * The "Use my device location" GPS button in the location table. Tailwind's
+ * preflight strips a <button> to plain text; restore a proper button look.
  */
-.device-location-button {
-  display: inline-block;
-  margin: 0;
-  padding: 0.45rem 0.9rem;
-  font: inherit;
-  font-size: 0.9rem;
-  font-weight: 600;
-  line-height: 1.2;
-  color: #fff;
-  background-color: #4f46e5; /* indigo-600 */
-  border: 1px solid transparent;
-  border-radius: 6px;
-  cursor: pointer;
-  transition:
-    background-color 0.15s ease,
-    opacity 0.15s ease;
-}
-
-.device-location-button:hover:not(:disabled) {
-  background-color: #4338ca; /* indigo-700 */
-}
-
-.device-location-button:disabled {
-  opacity: 0.6;
-  cursor: default;
-}
-
-.dark .device-location-button {
-  background-color: #6366f1; /* indigo-500 */
-}
-
-.dark .device-location-button:hover:not(:disabled) {
-  background-color: #818cf8; /* indigo-400 */
-}
-
-/* Location input row (city autocomplete + Set + GPS buttons) */
-.location-input-row {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  flex-wrap: wrap;
-  width: 100%;
-}
-
-.location-input-wrapper {
-  position: relative;
-  flex: 1;
-  min-width: 160px;
-}
-
-.location-input {
-  width: 100%;
-  padding: 0.35rem 0.6rem;
-  font: inherit;
-  font-size: 0.9rem;
-  line-height: 1.4;
-  border: 1px solid #cbd5e1;
-  border-radius: 6px;
-  background: transparent;
-  color: inherit;
-  box-sizing: border-box;
-}
-
-.location-input:focus {
-  outline: 2px solid #4f46e5;
-  outline-offset: 1px;
-  border-color: #4f46e5;
-}
-
-.dark .location-input {
-  border-color: #475569;
-}
-
-.dark .location-input:focus {
-  outline-color: #818cf8;
-  border-color: #818cf8;
-}
-
-.location-suggestions {
-  position: absolute;
-  top: calc(100% + 2px);
-  left: 0;
-  right: 0;
-  z-index: 50;
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  background: #fff;
-  border: 1px solid #cbd5e1;
-  border-radius: 6px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-  max-height: 220px;
-  overflow-y: auto;
-}
-
-.dark .location-suggestions {
-  background: #1e293b;
-  border-color: #475569;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
-}
-
-.location-suggestions li {
-  padding: 0.45rem 0.75rem;
-  cursor: pointer;
-  font-size: 0.82rem;
-  line-height: 1.35;
-  border-bottom: 1px solid #f1f5f9;
-}
-
-.location-suggestions li:last-child {
-  border-bottom: none;
-}
-
-.location-suggestions li:hover {
-  background: #f8fafc;
-}
-
-.dark .location-suggestions li {
-  border-color: #334155;
-}
-
-.dark .location-suggestions li:hover {
-  background: #334155;
-}
-
-.location-set-button,
 .location-gps-button {
   display: inline-flex;
   align-items: center;
@@ -167,23 +40,19 @@
   transition: background-color 0.15s ease, opacity 0.15s ease;
 }
 
-.location-set-button:hover:not(:disabled),
 .location-gps-button:hover:not(:disabled) {
   background-color: #4338ca;
 }
 
-.location-set-button:disabled,
 .location-gps-button:disabled {
   opacity: 0.4;
   cursor: default;
 }
 
-.dark .location-set-button,
 .dark .location-gps-button {
   background-color: #6366f1;
 }
 
-.dark .location-set-button:hover:not(:disabled),
 .dark .location-gps-button:hover:not(:disabled) {
   background-color: #818cf8;
 }

--- a/app/location-input.jsx
+++ b/app/location-input.jsx
@@ -1,17 +1,7 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useState } from 'react'
 import { useRouter } from 'next/navigation'
-
-async function nominatimSearch(query) {
-  if (!query || query.length < 3) return []
-  const url =
-    `https://nominatim.openstreetmap.org/search` +
-    `?format=jsonv2&q=${encodeURIComponent(query)}&limit=5&addressdetails=0`
-  const res = await fetch(url)
-  if (!res.ok) return []
-  return await res.json()
-}
 
 function setLocationCookie(lat, lon) {
   const value = encodeURIComponent(JSON.stringify({ lat, lon }))
@@ -34,89 +24,26 @@ function GpsIcon({ spinning }) {
   )
 }
 
-export default function LocationInput({ initialPlace }) {
+export default function GpsButton() {
   const router = useRouter()
-  const [value, setValue] = useState(initialPlace ?? '')
-  const [suggestions, setSuggestions] = useState([])
-  const [pendingCoords, setPendingCoords] = useState(null)
-  const [isDirty, setIsDirty] = useState(false)
   const [locating, setLocating] = useState(false)
-  const [gpsError, setGpsError] = useState(null)
-  const debounceRef = useRef(null)
-  const wrapperRef = useRef(null)
-
-  // Close suggestions when clicking outside.
-  useEffect(() => {
-    const handler = e => {
-      if (wrapperRef.current && !wrapperRef.current.contains(e.target)) {
-        setSuggestions([])
-      }
-    }
-    document.addEventListener('mousedown', handler)
-    return () => document.removeEventListener('mousedown', handler)
-  }, [])
-
-  const handleChange = e => {
-    const v = e.target.value
-    setValue(v)
-    setIsDirty(true)
-    setPendingCoords(null)
-
-    clearTimeout(debounceRef.current)
-    debounceRef.current = setTimeout(async () => {
-      setSuggestions(await nominatimSearch(v))
-    }, 300)
-  }
-
-  const selectSuggestion = s => {
-    setValue(s.display_name)
-    setSuggestions([])
-    setPendingCoords({ lat: parseFloat(s.lat), lon: parseFloat(s.lon) })
-    setIsDirty(true)
-  }
-
-  const handleSet = async () => {
-    let coords = pendingCoords
-    if (!coords) {
-      const results = await nominatimSearch(value)
-      if (!results.length) return
-      coords = { lat: parseFloat(results[0].lat), lon: parseFloat(results[0].lon) }
-    }
-    setLocationCookie(coords.lat, coords.lon)
-    setIsDirty(false)
-    setPendingCoords(null)
-    router.refresh()
-  }
+  const [error, setError] = useState(null)
 
   const handleGps = () => {
     if (!('geolocation' in navigator)) {
-      setGpsError('Geolocation not supported.')
+      setError('Geolocation not supported.')
       return
     }
     setLocating(true)
-    setGpsError(null)
+    setError(null)
     navigator.geolocation.getCurrentPosition(
-      async pos => {
-        const { latitude, longitude } = pos.coords
-        // Reverse geocode to update the text box immediately.
-        try {
-          const res = await fetch(
-            `https://nominatim.openstreetmap.org/reverse?format=jsonv2&lat=${latitude}&lon=${longitude}&zoom=10`
-          )
-          if (res.ok) {
-            const data = await res.json()
-            const a = data.address ?? {}
-            const city = a.city ?? a.town ?? a.village ?? a.hamlet ?? a.county ?? a.suburb
-            const parts = [city, a.state, a.country_code?.toUpperCase() ?? a.country].filter(Boolean)
-            if (parts.length > 0) setValue(parts.join(', '))
-          }
-        } catch {}
-        setLocationCookie(latitude, longitude)
+      pos => {
+        setLocationCookie(pos.coords.latitude, pos.coords.longitude)
         setLocating(false)
         router.refresh()
       },
       err => {
-        setGpsError(err.message)
+        setError(err.message)
         setLocating(false)
       },
       { enableHighAccuracy: true, timeout: 10000 }
@@ -124,40 +51,7 @@ export default function LocationInput({ initialPlace }) {
   }
 
   return (
-    <span className="location-input-row">
-      <span className="location-input-wrapper" ref={wrapperRef}>
-        <input
-          type="text"
-          className="location-input"
-          value={value}
-          onChange={handleChange}
-          placeholder="City, state, or address…"
-          aria-label="Location"
-          aria-autocomplete="list"
-        />
-        {suggestions.length > 0 && (
-          <ul className="location-suggestions" role="listbox">
-            {suggestions.map((s, i) => (
-              <li
-                key={i}
-                role="option"
-                aria-selected={false}
-                onMouseDown={() => selectSuggestion(s)}
-              >
-                {s.display_name}
-              </li>
-            ))}
-          </ul>
-        )}
-      </span>
-      <button
-        type="button"
-        className="location-set-button"
-        onClick={handleSet}
-        disabled={!isDirty}
-      >
-        Set
-      </button>
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.5rem' }}>
       <button
         type="button"
         className="location-gps-button"
@@ -167,9 +61,7 @@ export default function LocationInput({ initialPlace }) {
       >
         <GpsIcon spinning={locating} />
       </button>
-      {gpsError && (
-        <span className="location-gps-error">{gpsError}</span>
-      )}
+      {error && <span className="location-gps-error">{error}</span>}
     </span>
   )
 }

--- a/app/location-table.jsx
+++ b/app/location-table.jsx
@@ -1,7 +1,7 @@
 import { Table } from 'nextra/components'
 import { LiveClock } from './sun/live'
 import { fmt } from './sun/solar'
-import LocationInput from './location-input'
+import GpsButton from './location-input'
 
 export default function LocationTable({ loc, showClock = true }) {
   const { lat, lon, place, deviceLat, deviceLon, devicePlace } = loc
@@ -39,9 +39,13 @@ export default function LocationTable({ loc, showClock = true }) {
         <Table.Tr>
           <Table.Th>Location</Table.Th>
           <Table.Td>
-            <LocationInput
-              initialPlace={devicePlace ?? place ?? ''}
-            />
+            {devicePlace ?? place ?? <em>unknown</em>}
+          </Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+          <Table.Th>Device location</Table.Th>
+          <Table.Td>
+            <GpsButton />
           </Table.Td>
         </Table.Tr>
         {showClock && (


### PR DESCRIPTION
## Summary

- Location is now displayed as plain read-only text (no more autocomplete input or Set button)
- The GPS button remains to share device coordinates
- Removes Nominatim search, debounce logic, suggestion dropdown, and Set button from `location-input.jsx`
- Removes all associated CSS: `.device-location-button`, `.location-input*`, `.location-suggestions*`, `.location-set-button`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKLhDh1nTY9hAhNSJu26h5

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKLhDh1nTY9hAhNSJu26h5)_