### PR TITLE
Fix dt/dd baseline misalignment in tree tile details

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -230,8 +230,15 @@
   display: grid;
   grid-template-columns: auto 1fr;
   gap: 0.15rem 0.6rem;
+  align-items: baseline;
   font-size: 0.8rem;
   margin: 0;
+}
+
+.tree-tile-details dt,
+.tree-tile-details dd {
+  margin: 0;
+  padding: 0;
 }
 
 .tree-tile-details dt {


### PR DESCRIPTION
## Summary

- Adds `align-items: baseline` to `.tree-tile-details` grid so `<dt>` labels and `<dd>` values share the same text baseline
- Resets browser default `margin` and `padding` on `dt` and `dd` to remove the `margin-inline-start` that was pushing `dd` off-center

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKLhDh1nTY9hAhNSJu26h5

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKLhDh1nTY9hAhNSJu26h5)_