### PR TITLE
Add unlinked /apps/sextant accelerometer page

### DIFF
--- a/app/apps/sextant/page.jsx
+++ b/app/apps/sextant/page.jsx
@@ -1,0 +1,25 @@
+import { useMDXComponents } from '../../../mdx-components'
+import { LiveSextant } from '../../sextant/live'
+
+export const metadata = {
+  title: 'Sextant',
+  description:
+    'Live accelerometer readings from your device, used to determine which way is down.'
+}
+
+export const dynamic = 'force-dynamic'
+
+const Wrapper = useMDXComponents().wrapper
+
+export default function SextantPage() {
+  return (
+    <Wrapper metadata={{ title: 'Sextant' }}>
+      <h2>Accelerometer</h2>
+      <p>
+        Gravity points along the largest acceleration component. Hold the
+        device still and the vector below should approximate <em>down</em>.
+      </p>
+      <LiveSextant />
+    </Wrapper>
+  )
+}

--- a/app/sextant/live.jsx
+++ b/app/sextant/live.jsx
@@ -1,0 +1,114 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Table } from 'nextra/components'
+
+const PHI = (1 + Math.sqrt(5)) / 2
+const REFRESH_MS = (PHI / 5) * 1000
+
+function fmt(n, digits = 3) {
+  if (n === null || n === undefined || Number.isNaN(n)) return '—'
+  return n.toFixed(digits)
+}
+
+export function LiveSextant() {
+  const [reading, setReading] = useState({ x: null, y: null, z: null })
+  const [permission, setPermission] = useState('unknown')
+  const [supported, setSupported] = useState(true)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    if (!('DeviceMotionEvent' in window)) {
+      setSupported(false)
+      return
+    }
+
+    let latest = { x: null, y: null, z: null }
+    const onMotion = (event) => {
+      const g = event.accelerationIncludingGravity
+      if (!g) return
+      latest = { x: g.x, y: g.y, z: g.z }
+    }
+
+    const tick = setInterval(() => {
+      setReading(latest)
+    }, REFRESH_MS)
+
+    const attach = () => window.addEventListener('devicemotion', onMotion)
+
+    const NeedsPermission =
+      typeof DeviceMotionEvent !== 'undefined' &&
+      typeof DeviceMotionEvent.requestPermission === 'function'
+
+    if (NeedsPermission) {
+      setPermission('needed')
+    } else {
+      setPermission('granted')
+      attach()
+    }
+
+    return () => {
+      clearInterval(tick)
+      window.removeEventListener('devicemotion', onMotion)
+    }
+  }, [])
+
+  const requestPermission = async () => {
+    try {
+      const result = await DeviceMotionEvent.requestPermission()
+      setPermission(result)
+      if (result === 'granted') {
+        window.addEventListener('devicemotion', (event) => {
+          const g = event.accelerationIncludingGravity
+          if (!g) return
+          setReading({ x: g.x, y: g.y, z: g.z })
+        })
+      }
+    } catch (err) {
+      setPermission('denied')
+    }
+  }
+
+  if (!supported) {
+    return <p>Your browser does not expose accelerometer data.</p>
+  }
+
+  const { x, y, z } = reading
+  const magnitude =
+    x === null || y === null || z === null
+      ? null
+      : Math.sqrt(x * x + y * y + z * z)
+
+  return (
+    <>
+      {permission === 'needed' && (
+        <p>
+          <button onClick={requestPermission}>Enable accelerometer</button>
+        </p>
+      )}
+      {permission === 'denied' && (
+        <p>Accelerometer access was denied.</p>
+      )}
+      <Table>
+        <tbody>
+          <Table.Tr>
+            <Table.Th>x (m/s²)</Table.Th>
+            <Table.Td>{fmt(x)}</Table.Td>
+          </Table.Tr>
+          <Table.Tr>
+            <Table.Th>y (m/s²)</Table.Th>
+            <Table.Td>{fmt(y)}</Table.Td>
+          </Table.Tr>
+          <Table.Tr>
+            <Table.Th>z (m/s²)</Table.Th>
+            <Table.Td>{fmt(z)}</Table.Td>
+          </Table.Tr>
+          <Table.Tr>
+            <Table.Th>magnitude</Table.Th>
+            <Table.Td>{fmt(magnitude)}</Table.Td>
+          </Table.Tr>
+        </tbody>
+      </Table>
+    </>
+  )
+}

--- a/app/sextant/live.jsx
+++ b/app/sextant/live.jsx
@@ -12,18 +12,19 @@ function fmt(n, digits = 3) {
   return n.toFixed(digits)
 }
 
-function tiltTransform(x, y, z) {
+function tiltTransform(x, y, z, heading) {
   if (x === null || y === null || z === null) return 'none'
   const pitch = Math.atan2(y, z) * RAD_TO_DEG
   const roll = Math.atan2(-x, Math.sqrt(y * y + z * z)) * RAD_TO_DEG
-  return `rotateX(${pitch}deg) rotateY(${roll}deg)`
+  const yaw = heading == null ? 0 : -heading
+  return `rotateZ(${yaw}deg) rotateX(${pitch}deg) rotateY(${roll}deg)`
 }
 
 export function LiveSextant() {
-  const [reading, setReading] = useState({ x: null, y: null, z: null })
+  const [reading, setReading] = useState({ x: null, y: null, z: null, heading: null })
   const [permission, setPermission] = useState('unknown')
   const [supported, setSupported] = useState(true)
-  const latestRef = useRef({ x: null, y: null, z: null })
+  const latestRef = useRef({ x: null, y: null, z: null, heading: null })
   const squareRef = useRef(null)
 
   useEffect(() => {
@@ -36,14 +37,25 @@ export function LiveSextant() {
     const onMotion = (event) => {
       const g = event.accelerationIncludingGravity
       if (!g) return
-      latestRef.current = { x: g.x, y: g.y, z: g.z }
+      latestRef.current = { ...latestRef.current, x: g.x, y: g.y, z: g.z }
+    }
+
+    const onOrientation = (event) => {
+      const heading =
+        typeof event.webkitCompassHeading === 'number'
+          ? event.webkitCompassHeading
+          : typeof event.alpha === 'number'
+            ? (360 - event.alpha) % 360
+            : null
+      if (heading == null) return
+      latestRef.current = { ...latestRef.current, heading }
     }
 
     let rafId = 0
     const animate = () => {
-      const { x, y, z } = latestRef.current
+      const { x, y, z, heading } = latestRef.current
       if (squareRef.current && x !== null) {
-        squareRef.current.style.transform = tiltTransform(x, y, z)
+        squareRef.current.style.transform = tiltTransform(x, y, z, heading)
       }
       rafId = requestAnimationFrame(animate)
     }
@@ -52,15 +64,16 @@ export function LiveSextant() {
       setReading(latestRef.current)
     }, REFRESH_MS)
 
-    const NeedsPermission =
+    const NeedsMotionPermission =
       typeof DeviceMotionEvent !== 'undefined' &&
       typeof DeviceMotionEvent.requestPermission === 'function'
 
-    if (NeedsPermission) {
+    if (NeedsMotionPermission) {
       setPermission('needed')
     } else {
       setPermission('granted')
       window.addEventListener('devicemotion', onMotion)
+      window.addEventListener('deviceorientation', onOrientation)
       rafId = requestAnimationFrame(animate)
     }
 
@@ -68,24 +81,47 @@ export function LiveSextant() {
       clearInterval(tick)
       cancelAnimationFrame(rafId)
       window.removeEventListener('devicemotion', onMotion)
+      window.removeEventListener('deviceorientation', onOrientation)
     }
   }, [])
 
   const requestPermission = async () => {
     try {
-      const result = await DeviceMotionEvent.requestPermission()
+      const motionResult = await DeviceMotionEvent.requestPermission()
+      let orientationResult = 'granted'
+      if (
+        typeof DeviceOrientationEvent !== 'undefined' &&
+        typeof DeviceOrientationEvent.requestPermission === 'function'
+      ) {
+        orientationResult = await DeviceOrientationEvent.requestPermission()
+      }
+      const result =
+        motionResult === 'granted' && orientationResult === 'granted'
+          ? 'granted'
+          : 'denied'
       setPermission(result)
       if (result === 'granted') {
         const onMotion = (event) => {
           const g = event.accelerationIncludingGravity
           if (!g) return
-          latestRef.current = { x: g.x, y: g.y, z: g.z }
+          latestRef.current = { ...latestRef.current, x: g.x, y: g.y, z: g.z }
+        }
+        const onOrientation = (event) => {
+          const heading =
+            typeof event.webkitCompassHeading === 'number'
+              ? event.webkitCompassHeading
+              : typeof event.alpha === 'number'
+                ? (360 - event.alpha) % 360
+                : null
+          if (heading == null) return
+          latestRef.current = { ...latestRef.current, heading }
         }
         window.addEventListener('devicemotion', onMotion)
+        window.addEventListener('deviceorientation', onOrientation)
         const animate = () => {
-          const { x, y, z } = latestRef.current
+          const { x, y, z, heading } = latestRef.current
           if (squareRef.current && x !== null) {
-            squareRef.current.style.transform = tiltTransform(x, y, z)
+            squareRef.current.style.transform = tiltTransform(x, y, z, heading)
           }
           requestAnimationFrame(animate)
         }
@@ -100,7 +136,7 @@ export function LiveSextant() {
     return <p>Your browser does not expose accelerometer data.</p>
   }
 
-  const { x, y, z } = reading
+  const { x, y, z, heading } = reading
   const magnitude =
     x === null || y === null || z === null
       ? null
@@ -155,6 +191,10 @@ export function LiveSextant() {
           <Table.Tr>
             <Table.Th>magnitude</Table.Th>
             <Table.Td>{fmt(magnitude)}</Table.Td>
+          </Table.Tr>
+          <Table.Tr>
+            <Table.Th>compass heading (°)</Table.Th>
+            <Table.Td>{fmt(heading, 1)}</Table.Td>
           </Table.Tr>
         </tbody>
       </Table>

--- a/app/sextant/live.jsx
+++ b/app/sextant/live.jsx
@@ -1,20 +1,30 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Table } from 'nextra/components'
 
 const PHI = (1 + Math.sqrt(5)) / 2
 const REFRESH_MS = (PHI / 5) * 1000
+const RAD_TO_DEG = 180 / Math.PI
 
 function fmt(n, digits = 3) {
   if (n === null || n === undefined || Number.isNaN(n)) return '—'
   return n.toFixed(digits)
 }
 
+function tiltTransform(x, y, z) {
+  if (x === null || y === null || z === null) return 'none'
+  const pitch = Math.atan2(y, z) * RAD_TO_DEG
+  const roll = Math.atan2(-x, Math.sqrt(y * y + z * z)) * RAD_TO_DEG
+  return `rotateX(${pitch}deg) rotateY(${roll}deg)`
+}
+
 export function LiveSextant() {
   const [reading, setReading] = useState({ x: null, y: null, z: null })
   const [permission, setPermission] = useState('unknown')
   const [supported, setSupported] = useState(true)
+  const latestRef = useRef({ x: null, y: null, z: null })
+  const squareRef = useRef(null)
 
   useEffect(() => {
     if (typeof window === 'undefined') return
@@ -23,18 +33,24 @@ export function LiveSextant() {
       return
     }
 
-    let latest = { x: null, y: null, z: null }
     const onMotion = (event) => {
       const g = event.accelerationIncludingGravity
       if (!g) return
-      latest = { x: g.x, y: g.y, z: g.z }
+      latestRef.current = { x: g.x, y: g.y, z: g.z }
+    }
+
+    let rafId = 0
+    const animate = () => {
+      const { x, y, z } = latestRef.current
+      if (squareRef.current && x !== null) {
+        squareRef.current.style.transform = tiltTransform(x, y, z)
+      }
+      rafId = requestAnimationFrame(animate)
     }
 
     const tick = setInterval(() => {
-      setReading(latest)
+      setReading(latestRef.current)
     }, REFRESH_MS)
-
-    const attach = () => window.addEventListener('devicemotion', onMotion)
 
     const NeedsPermission =
       typeof DeviceMotionEvent !== 'undefined' &&
@@ -44,11 +60,13 @@ export function LiveSextant() {
       setPermission('needed')
     } else {
       setPermission('granted')
-      attach()
+      window.addEventListener('devicemotion', onMotion)
+      rafId = requestAnimationFrame(animate)
     }
 
     return () => {
       clearInterval(tick)
+      cancelAnimationFrame(rafId)
       window.removeEventListener('devicemotion', onMotion)
     }
   }, [])
@@ -58,11 +76,20 @@ export function LiveSextant() {
       const result = await DeviceMotionEvent.requestPermission()
       setPermission(result)
       if (result === 'granted') {
-        window.addEventListener('devicemotion', (event) => {
+        const onMotion = (event) => {
           const g = event.accelerationIncludingGravity
           if (!g) return
-          setReading({ x: g.x, y: g.y, z: g.z })
-        })
+          latestRef.current = { x: g.x, y: g.y, z: g.z }
+        }
+        window.addEventListener('devicemotion', onMotion)
+        const animate = () => {
+          const { x, y, z } = latestRef.current
+          if (squareRef.current && x !== null) {
+            squareRef.current.style.transform = tiltTransform(x, y, z)
+          }
+          requestAnimationFrame(animate)
+        }
+        requestAnimationFrame(animate)
       }
     } catch (err) {
       setPermission('denied')
@@ -86,9 +113,31 @@ export function LiveSextant() {
           <button onClick={requestPermission}>Enable accelerometer</button>
         </p>
       )}
-      {permission === 'denied' && (
-        <p>Accelerometer access was denied.</p>
-      )}
+      {permission === 'denied' && <p>Accelerometer access was denied.</p>}
+      <div
+        style={{
+          perspective: '600px',
+          height: '240px',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          margin: '1rem 0',
+        }}
+      >
+        <div
+          ref={squareRef}
+          style={{
+            width: '160px',
+            height: '160px',
+            background:
+              'linear-gradient(135deg, rgba(99,102,241,0.6), rgba(236,72,153,0.6))',
+            border: '2px solid currentColor',
+            borderRadius: '8px',
+            transformStyle: 'preserve-3d',
+            transition: 'transform 60ms linear',
+          }}
+        />
+      </div>
       <Table>
         <tbody>
           <Table.Tr>


### PR DESCRIPTION
## Summary
- New page at `/apps/sextant` (not linked from `ToyNav` or any other page)
- Captures `devicemotion`'s `accelerationIncludingGravity` and prints x/y/z + magnitude
- Refreshes the displayed values every phi/5 seconds (~324 ms)
- Includes the iOS Safari `DeviceMotionEvent.requestPermission()` flow

## Test plan
- [ ] Visit `/apps/sextant` on a phone — values update ~3×/sec
- [ ] On iOS Safari, tap "Enable accelerometer" and confirm values populate
- [ ] On desktop with no sensor, page renders without errors


---
_Generated by [Claude Code](https://claude.ai/code/session_015iQnzezgk52HKa1ChEHwh9)_