### PR TITLE
Use www.philihp.com as the canonical web host

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-https://philihp.com
+https://www.philihp.com
 
 Personal site, built with [Next.js](https://nextjs.org) and the
 [Nextra](https://nextra.site) blog theme, deployed on

--- a/app/feed.xml/route.js
+++ b/app/feed.xml/route.js
@@ -1,6 +1,6 @@
 import { getPosts } from '../get-posts'
 
-const SITE_URL = 'https://philihp.com'
+const SITE_URL = 'https://www.philihp.com'
 const CONFIG = {
   title: 'Philihp Busby Blog Posts',
   description: 'Via the mind and mechanism of Philihp Busby.',

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -6,7 +6,7 @@ import 'nextra-theme-blog/style.css'
 import './globals.css'
 import { PUBLICATION_URI } from './.well-known/site.standard.publication/route.js'
 
-const SITE_URL = 'https://philihp.com'
+const SITE_URL = 'https://www.philihp.com'
 
 export const metadata = {
   metadataBase: new URL(SITE_URL),

--- a/app/sitemap.js
+++ b/app/sitemap.js
@@ -1,6 +1,6 @@
 import { getPosts } from './get-posts'
 
-const SITE_URL = 'https://philihp.com'
+const SITE_URL = 'https://www.philihp.com'
 
 export default async function sitemap() {
   const posts = await getPosts()


### PR DESCRIPTION
Follow-up to #114. `philihp.com` is the identity — the Bluesky handle, and the zone holding the `_atproto` TXT record that resolves it to `did:plc:mnbueka7mnf5ts5rzmjy34z2`. The website is one service that identity runs, and it lives at `www`, which is where the apex has been redirecting all along:

```
$ curl -D- https://philihp.com/
HTTP/2 307
location: https://www.philihp.com/
```

`SITE_URL` still named the apex, so canonical URLs, sitemap entries, and every RSS link pointed at a host that 307s before reaching the real one.

## Changes

- `app/layout.jsx`, `app/sitemap.js`, `app/feed.xml/route.js` — `SITE_URL` now `https://www.philihp.com`.
- `README.md` — same, for the site link at the top.

Left alone deliberately, because they identify rather than locate: the Bluesky profile link (`bsky.app/profile/philihp.com`), the `philihp.com/sun-moon-pages` User-Agent in `app/geo.js`, the apex claim in the signed `public/.well-known/keybase.txt`, and apex references in historical post content.

## Verified

`npm run build` compiles clean. Against `next start`:

```
$ curl localhost:3113/feed.xml | grep -oE '<link>[^<]*</link>' | head -2
<link>https://www.philihp.com/</link>
<link>https://www.philihp.com/2026/announcing-pointille.html</link>

$ curl localhost:3113/sitemap.xml | grep -oE '<loc>[^<]*</loc>' | head -2
<loc>https://www.philihp.com/</loc>
<loc>https://www.philihp.com/about</loc>
```

`/.well-known/site.standard.publication` is unchanged and still serves the AT-URI — that names the identity by DID, so it's unaffected by which host serves the site.

## Bearing on the standard.site record

This settles which `url` the publication record should carry. The lexicon documents `url` as "Base publication url" — a location where documents are served, not an identity — so it takes the www host, while the record stays keyed by the DID:

```json
{
  "$type": "site.standard.publication",
  "url": "https://www.philihp.com",
  "name": "Philihp Busby",
  "description": "Via the mind and mechanism of Philihp Busby.",
  "preferences": { "showInDiscover": true }
}
```

That also sidesteps the verification problem the apex redirect would have caused. Verifiers fetch `{url}/.well-known/site.standard.publication`; pointing `url` at www means a direct 200 rather than a 307 the verifier may or may not follow.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhxG3fHfTUEkuweAgj33zi)_