### PR TITLE
Publish a standard.site document record per post

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,23 @@ content/2026/my-new-post.html.md   ->   /2026/my-new-post.html
   `content/2026/announcing-pointille.html.mdx`).
 - Open a PR — Vercel will create a preview deployment.
 
+## Publish to standard.site
+
+Posts are mirrored to AT Protocol as [standard.site](https://standard.site)
+`site.standard.document` records, so clients can discover them from the
+network side. After adding or editing a post:
+
+```bash
+npm run sync-documents -- --dry-run    # show what would change
+BSKY_APP_PASSWORD=xxxx-xxxx-xxxx-xxxx npm run sync-documents
+```
+
+Records are keyed by post route, so the script only writes the posts whose
+metadata actually changed. Each post's `<head>` carries a matching
+`<link rel="site.standard.document">` tag, which is what ties the rendered
+page to its record. The publication record is separate and written by hand;
+`/.well-known/site.standard.publication` points at it.
+
 ## Create a redirect
 
 Redirects are generated into `redirects.json` and wired up by

--- a/app/[...mdxPath]/page.jsx
+++ b/app/[...mdxPath]/page.jsx
@@ -1,5 +1,6 @@
 import { generateStaticParamsFor, importPage } from 'nextra/pages'
 import { useMDXComponents as getMDXComponents } from '../../mdx-components'
+import { documentUri } from '../standard-site.js'
 
 export const generateStaticParams = generateStaticParamsFor('mdxPath')
 
@@ -19,8 +20,17 @@ export default async function Page(props) {
     metadata,
     sourceCode
   } = await importPage(params.mdxPath)
+
+  // Only posts get a site.standard.document record; the standalone pages
+  // (/about, /pgp, /lightning) carry no date and are not part of the
+  // publication. See scripts/sync-documents.mjs, which mints the same rkeys.
+  const route = `/${(params.mdxPath || []).join('/')}`
+
   return (
     <Wrapper toc={toc} metadata={metadata} sourceCode={sourceCode}>
+      {metadata.date && (
+        <link rel="site.standard.document" href={documentUri(route)} />
+      )}
       <MDXContent {...props} params={params} />
     </Wrapper>
   )

--- a/app/standard-site.js
+++ b/app/standard-site.js
@@ -1,0 +1,15 @@
+import { PUBLICATION_URI } from './.well-known/site.standard.publication/route.js'
+
+// at://<did>/site.standard.publication/self
+const DID = PUBLICATION_URI.split('/')[2]
+
+// Record keys cannot contain slashes, so a post's route doubles as its rkey
+// with the separators swapped: /2026/announcing-pointille.html becomes
+// 2026-announcing-pointille.html. Deriving it rather than generating a TID
+// keeps it stable, so re-syncing a post edits its record instead of leaving a
+// second copy behind. Everything the routes produce is already within the
+// record-key charset ([A-Za-z0-9._~:-]).
+export const documentRkey = route => route.replace(/^\//, '').replaceAll('/', '-')
+
+export const documentUri = route =>
+  `at://${DID}/site.standard.document/${documentRkey(route)}`

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "next build",
     "postbuild": "pagefind --site .next/server/app --output-path public/_pagefind",
     "start": "next start",
-    "convert": "node scripts/convert-posts.mjs"
+    "convert": "node scripts/convert-posts.mjs",
+    "sync-documents": "node scripts/sync-documents.mjs"
   },
   "dependencies": {
     "@vercel/blob": "^2.6.1",

--- a/scripts/sync-documents.mjs
+++ b/scripts/sync-documents.mjs
@@ -1,0 +1,173 @@
+// Publishes a `site.standard.document` record for every post in content/, so
+// standard.site clients can discover the writing here from the AT Protocol
+// side. See https://standard.site/docs/lexicons/document.
+//
+//   BSKY_APP_PASSWORD=xxxx-xxxx-xxxx-xxxx npm run sync-documents
+//   npm run sync-documents -- --dry-run
+//
+// Get an app password from https://bsky.app/settings/app-passwords — this
+// never wants the account password. Records are keyed by post route (see
+// documentRkey), so the script is idempotent: it writes only the posts whose
+// metadata actually changed, and re-running it after an edit updates the
+// record in place rather than leaving a duplicate.
+//
+// The publication record itself is not managed here — it is written once by
+// hand and rarely changes.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import matter from 'gray-matter'
+import { PUBLICATION_URI } from '../app/.well-known/site.standard.publication/route.js'
+import { documentRkey } from '../app/standard-site.js'
+
+const ROOT = path.resolve(import.meta.dirname, '..')
+const CONTENT_DIR = path.join(ROOT, 'content')
+const COLLECTION = 'site.standard.document'
+const DID = PUBLICATION_URI.split('/')[2]
+
+const dryRun = process.argv.includes('--dry-run')
+
+// --- the records we want -----------------------------------------------------
+
+const readPosts = () => {
+  const files = []
+  const walk = dir => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name)
+      if (entry.isDirectory()) walk(full)
+      else if (/\.mdx?$/.test(entry.name)) files.push(full)
+    }
+  }
+  walk(CONTENT_DIR)
+
+  return files
+    .map(file => {
+      const { data } = matter(fs.readFileSync(file, 'utf8'))
+      // Nextra strips the trailing .md/.mdx, so the file path is the route.
+      const route = `/${path.relative(CONTENT_DIR, file).replace(/\.mdx?$/, '')}`
+      return { route, frontMatter: data }
+    })
+    // Pages without a date (/about, /pgp, /lightning) are not posts.
+    .filter(post => post.frontMatter.date)
+    .sort((a, b) => a.route.localeCompare(b.route))
+}
+
+const buildRecord = ({ route, frontMatter }) => {
+  const record = {
+    $type: COLLECTION,
+    site: PUBLICATION_URI,
+    path: route,
+    title: String(frontMatter.title),
+    publishedAt: new Date(frontMatter.date).toISOString()
+  }
+  if (frontMatter.tags?.length) record.tags = frontMatter.tags.map(String)
+  return record
+}
+
+// --- what the repo already holds ---------------------------------------------
+
+const xrpc = async (pds, method, { body, token, params } = {}) => {
+  const url = new URL(`${pds}/xrpc/${method}`)
+  for (const [key, value] of Object.entries(params || {})) {
+    url.searchParams.set(key, value)
+  }
+  const res = await fetch(url, {
+    method: body ? 'POST' : 'GET',
+    headers: {
+      ...(body && { 'Content-Type': 'application/json' }),
+      ...(token && { Authorization: `Bearer ${token}` })
+    },
+    ...(body && { body: JSON.stringify(body) })
+  })
+  if (!res.ok) {
+    throw new Error(`${method} ${res.status}: ${await res.text()}`)
+  }
+  return res.json()
+}
+
+const resolvePds = async did => {
+  const res = await fetch(`https://plc.directory/${did}`)
+  if (!res.ok) throw new Error(`could not resolve ${did}: ${res.status}`)
+  const doc = await res.json()
+  const pds = doc.service?.find(s => s.id === '#atproto_pds')?.serviceEndpoint
+  if (!pds) throw new Error(`no PDS listed in the DID document for ${did}`)
+  return pds
+}
+
+const listExisting = async pds => {
+  const existing = new Map()
+  let cursor
+  do {
+    const page = await xrpc(pds, 'com.atproto.repo.listRecords', {
+      params: { repo: DID, collection: COLLECTION, limit: 100, ...(cursor && { cursor }) }
+    })
+    for (const { uri, value } of page.records) {
+      existing.set(uri.split('/').pop(), value)
+    }
+    cursor = page.cursor
+  } while (cursor)
+  return existing
+}
+
+// Key order differs between what we build and what the PDS returns, so compare
+// on a stable serialisation rather than the raw JSON.
+const stable = value =>
+  JSON.stringify(value, (_, v) =>
+    v && typeof v === 'object' && !Array.isArray(v)
+      ? Object.fromEntries(Object.entries(v).sort(([a], [b]) => a.localeCompare(b)))
+      : v
+  )
+
+// --- go ----------------------------------------------------------------------
+
+const posts = readPosts()
+console.log(`${posts.length} posts in ${path.relative(ROOT, CONTENT_DIR)}/`)
+
+const pds = await resolvePds(DID)
+const existing = await listExisting(pds)
+console.log(`${existing.size} ${COLLECTION} records already in ${pds}`)
+
+const pending = posts
+  .map(post => ({ rkey: documentRkey(post.route), record: buildRecord(post) }))
+  .filter(({ rkey, record }) => stable(existing.get(rkey)) !== stable(record))
+
+const orphaned = [...existing.keys()].filter(
+  rkey => !posts.some(post => documentRkey(post.route) === rkey)
+)
+if (orphaned.length) {
+  console.log(`${orphaned.length} records have no matching post, left alone:`)
+  for (const rkey of orphaned) console.log(`  ${rkey}`)
+}
+
+if (!pending.length) {
+  console.log('everything up to date')
+  process.exit(0)
+}
+
+console.log(`${pending.length} to write:`)
+for (const { rkey } of pending) console.log(`  ${rkey}`)
+
+if (dryRun) {
+  console.log('\n--dry-run, stopping here')
+  process.exit(0)
+}
+
+const password = process.env.BSKY_APP_PASSWORD
+if (!password) {
+  console.error('\nBSKY_APP_PASSWORD is not set')
+  process.exit(1)
+}
+
+const { accessJwt } = await xrpc(pds, 'com.atproto.server.createSession', {
+  body: { identifier: DID, password }
+})
+
+for (const { rkey, record } of pending) {
+  await xrpc(pds, 'com.atproto.repo.putRecord', {
+    token: accessJwt,
+    body: { repo: DID, collection: COLLECTION, rkey, record }
+  })
+  console.log(`wrote ${rkey}`)
+}
+
+console.log(`\ndone, ${pending.length} written`)


### PR DESCRIPTION
Follow-up to #114 and #115. The publication record says this site exists; `site.standard.document` records say what's on it. This adds both halves — the records, and the `<link>` tag that ties each rendered post back to its record.

## Changes

- `app/standard-site.js` — derives a document rkey from a post route by swapping slashes for dashes (`/2026/announcing-pointille.html` → `2026-announcing-pointille.html`), and builds the AT-URI from it. Deriving rather than generating a TID keeps the key stable, so a re-sync edits the existing record instead of leaving a second copy. Everything the routes produce already falls inside the record-key charset (`[A-Za-z0-9._~:-]`) — checked across all 143 posts.
- `app/[...mdxPath]/page.jsx` — emits `<link rel="site.standard.document" href="at://…">` for posts. Gated on front-matter `date`, which is the same test `getPosts()` uses, so `/about`, `/pgp`, and `/lightning` are excluded.
- `scripts/sync-documents.mjs` + `npm run sync-documents` — walks `content/`, builds a record per post, and writes the ones that changed.
- `README.md` — a "Publish to standard.site" section covering the post-authoring workflow.

The page and the script mint rkeys through the same helper, so the tag and the record can't disagree.

## About the script

```
npm run sync-documents -- --dry-run
BSKY_APP_PASSWORD=xxxx-xxxx-xxxx-xxxx npm run sync-documents
```

- Resolves the PDS from the DID document rather than hardcoding it, so a PDS migration doesn't need a code change.
- Authenticates as the DID with an app password from the environment. No credentials in the repo.
- `listRecords` first, then diffs on a key-order-stable serialisation and writes only what actually changed — a routine run after one new post writes one record, not 143. `updatedAt` is deliberately not set, since a fresh timestamp each run would force a write every time.
- Reports records that no longer match a post but doesn't delete them; unpublishing is a decision worth making by hand.
- `--dry-run` prints the plan and stops before touching credentials.

## Verified

`npm run build` compiles clean. Against `next start`:

```
/2026/announcing-pointille.html -> <link rel="site.standard.document" href="at://did:plc:mnbueka7.../site.standard.document/2026-announcing-pointille.html"/>
/2004/1-2.html                  -> <link rel="site.standard.document" href="at://did:plc:mnbueka7.../site.standard.document/2004-1-2.html"/>
/about                          -> (none)
/pgp                            -> (none)
/ (home)                        -> (none)
```

and the tag lands inside `<head>`.

Dry run against the live repo:

```
$ npm run sync-documents -- --dry-run
143 posts in content/
0 site.standard.document records already in https://puffball.us-east.host.bsky.network
143 to write:
  2004-1-2.html
  …
  2026-announcing-pointille.html

--dry-run, stopping here
```

`gray-matter` parses all 146 content files without error; the 3 without a `date` are the standalone pages and are filtered out.

## Note

The publication record's `url` is still `https://philihp.com`. Since verifiers resolve a document's canonical URL as publication `url` + document `path`, that wants updating to `https://www.philihp.com` — separate from this diff, since the publication record is written by hand.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhxG3fHfTUEkuweAgj33zi)_