### PR TITLE
Move PUBLICATION_URI into app/standard-site.js

### DIFF
--- a/app/.well-known/site.standard.publication/route.js
+++ b/app/.well-known/site.standard.publication/route.js
@@ -1,16 +1,8 @@
-// standard.site (https://standard.site) publishes AT Protocol lexicons for
-// long-form writing. A `site.standard.publication` record describes this blog,
-// and is only trusted once this endpoint points back at it. Verifiers fetch
-// this and compare the body to the record's AT-URI.
-// See https://standard.site/docs/verification.
-//
-// did:plc:mnbueka7mnf5ts5rzmjy34z2 is the DID behind the @philihp.com handle.
-// Prefer the DID over the handle here — handles can be reassigned.
-export const PUBLICATION_URI =
-  'at://did:plc:mnbueka7mnf5ts5rzmjy34z2/site.standard.publication/self'
+import { PUBLICATION_URI } from '../../standard-site.js'
 
 export const dynamic = 'force-static'
 
+// Verifiers fetch this and compare the body to the publication record's AT-URI.
 export const GET = () =>
   new Response(`${PUBLICATION_URI}\n`, {
     headers: {

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -4,7 +4,7 @@ import { getPageMap } from 'nextra/page-map'
 import Script from 'next/script'
 import 'nextra-theme-blog/style.css'
 import './globals.css'
-import { PUBLICATION_URI } from './.well-known/site.standard.publication/route.js'
+import { PUBLICATION_URI } from './standard-site.js'
 
 const SITE_URL = 'https://www.philihp.com'
 

--- a/app/standard-site.js
+++ b/app/standard-site.js
@@ -1,7 +1,15 @@
-import { PUBLICATION_URI } from './.well-known/site.standard.publication/route.js'
+// standard.site (https://standard.site) publishes AT Protocol lexicons for
+// long-form writing: a `site.standard.publication` record describing this blog,
+// and a `site.standard.document` record per post.
+//
+// did:plc:mnbueka7mnf5ts5rzmjy34z2 is the DID behind the @philihp.com handle.
+// Prefer the DID over the handle — handles can be reassigned.
+export const DID = 'did:plc:mnbueka7mnf5ts5rzmjy34z2'
 
-// at://<did>/site.standard.publication/self
-const DID = PUBLICATION_URI.split('/')[2]
+// Served verbatim from /.well-known/site.standard.publication, which is what
+// ties the record to this domain, and echoed as a discovery hint in <head>.
+// See https://standard.site/docs/verification.
+export const PUBLICATION_URI = `at://${DID}/site.standard.publication/self`
 
 // Record keys cannot contain slashes, so a post's route doubles as its rkey
 // with the separators swapped: /2026/announcing-pointille.html becomes

--- a/scripts/sync-documents.mjs
+++ b/scripts/sync-documents.mjs
@@ -17,13 +17,11 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import matter from 'gray-matter'
-import { PUBLICATION_URI } from '../app/.well-known/site.standard.publication/route.js'
-import { documentRkey } from '../app/standard-site.js'
+import { DID, PUBLICATION_URI, documentRkey } from '../app/standard-site.js'
 
 const ROOT = path.resolve(import.meta.dirname, '..')
 const CONTENT_DIR = path.join(ROOT, 'content')
 const COLLECTION = 'site.standard.document'
-const DID = PUBLICATION_URI.split('/')[2]
 
 const dryRun = process.argv.includes('--dry-run')
 


### PR DESCRIPTION
Follow-up to #116. `PUBLICATION_URI` lived in the well-known route file from back when it was the only standard.site constant and had two consumers. Now that `app/standard-site.js` exists for the document helpers, every consumer reaches the module anyway — and importing one string meant pulling in a Next.js route handler to get it.

## Changes

- `app/standard-site.js` — now holds `DID`, `PUBLICATION_URI`, `documentRkey`, and `documentUri`. The DID becomes the single literal and both AT-URIs derive from it, which drops the `PUBLICATION_URI.split('/')[2]` that had been recovering it.
- `app/.well-known/site.standard.publication/route.js` — imports `PUBLICATION_URI`; down to the handler and its headers.
- `app/layout.jsx`, `scripts/sync-documents.mjs` — import from the module instead of the route.

No behavior change; the same strings come out the far end.

## Verified

`npm run build` compiles clean and still prerenders `○ /.well-known/site.standard.publication`. Against `next start`:

```
well-known       -> at://did:plc:mnbueka7.../site.standard.publication/self
publication hint -> <link rel="site.standard.publication" href="at://did:plc:mnbueka7.../site.standard.publication/self"/>
document tag     -> <link rel="site.standard.document" href="at://did:plc:mnbueka7.../site.standard.document/2004-1-2.html"/>
/about           -> (none)
```

`npm run sync-documents -- --dry-run` still resolves the PDS and reads the repo:

```
143 posts in content/
0 site.standard.document records already in https://puffball.us-east.host.bsky.network
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhxG3fHfTUEkuweAgj33zi)_