### PR TITLE
Draft a post on pointille's radius parameter

### DIFF
--- a/components/pointille.jsx
+++ b/components/pointille.jsx
@@ -119,7 +119,7 @@ function polygonCentroid(poly) {
   return [cx / (6 * A), cy / (6 * A)]
 }
 
-function pointille(polygon, n, { iterations = 30, seed = 1 } = {}) {
+function boundingBox(polygon) {
   let minX = Infinity,
     minY = Infinity,
     maxX = -Infinity,
@@ -130,24 +130,318 @@ function pointille(polygon, n, { iterations = 30, seed = 1 } = {}) {
     if (x > maxX) maxX = x
     if (y > maxY) maxY = y
   }
+  return [minX, minY, maxX, maxY]
+}
+
+function signedArea(polygon) {
+  let a = 0
+  for (let i = 0; i < polygon.length; i++) {
+    const [x0, y0] = polygon[i]
+    const [x1, y1] = polygon[(i + 1) % polygon.length]
+    a += x0 * y1 - x1 * y0
+  }
+  return a / 2
+}
+
+function seedPoints(polygon, n, seed, accept) {
+  const [minX, minY, maxX, maxY] = boundingBox(polygon)
   const W = maxX - minX,
     H = maxY - minY
-  const points = []
-  let i = seed
-  while (points.length < n && i < seed + 100000) {
-    const p = [minX + halton(i, 2) * W, minY + halton(i, 3) * H]
-    if (pointInPolygon(p, polygon)) points.push(p)
-    i++
+  const out = []
+  const budget = Math.max(1000, n * 2000)
+  for (let k = 0; k < budget && out.length < n; k++) {
+    const p = [minX + halton(seed + k, 2) * W, minY + halton(seed + k, 3) * H]
+    if (accept(p)) out.push(p)
   }
-  for (let it = 0; it < iterations; it++) {
-    const cells = voronoiCells(points, polygon)
-    for (let k = 0; k < points.length; k++) {
-      if (cells[k].length < 3) continue
-      const c = polygonCentroid(cells[k])
-      if (pointInPolygon(c, polygon)) points[k] = c
+  return out
+}
+
+function lloydRelax(polygon, iterations, clamp) {
+  return input => {
+    const points = input.map(p => [p[0], p[1]])
+    for (let it = 0; it < iterations; it++) {
+      const cells = voronoiCells(points, polygon)
+      for (let k = 0; k < points.length; k++) {
+        if (cells[k].length < 3) continue
+        const c = polygonCentroid(cells[k])
+        const q = clamp ? clamp(c) : c
+        if (pointInPolygon(q, polygon)) points[k] = q
+      }
+    }
+    return points
+  }
+}
+
+// --- circle packing (the `radius` option) ------------------------------------
+// Ported from the package's safe-region/separate modules. The guarantee is
+// enforced by verifyPacking, an exact check — the iterative clamp and push
+// steps below are only ever a way of reaching a layout that passes it.
+
+class PointilleFitError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'PointilleFitError'
+  }
+}
+
+function nearestOnSegment(p, a, b) {
+  const abx = b[0] - a[0],
+    aby = b[1] - a[1]
+  const lenSq = abx * abx + aby * aby
+  const t =
+    lenSq === 0
+      ? 0
+      : Math.min(
+          1,
+          Math.max(0, ((p[0] - a[0]) * abx + (p[1] - a[1]) * aby) / lenSq)
+        )
+  return [a[0] + t * abx, a[1] + t * aby]
+}
+
+function nearestBoundaryPoint(polygon) {
+  const n = polygon.length
+  return p => {
+    let best = { point: polygon[0], dist: Infinity, edge: 0 }
+    for (let i = 0; i < n; i++) {
+      const q = nearestOnSegment(p, polygon[i], polygon[(i + 1) % n])
+      const d = Math.hypot(p[0] - q[0], p[1] - q[1])
+      if (d < best.dist) best = { point: q, dist: d, edge: i }
+    }
+    return best
+  }
+}
+
+function distanceToBoundary(polygon) {
+  const nearest = nearestBoundaryPoint(polygon)
+  return p => nearest(p).dist
+}
+
+// Clip a polygon to the half-plane on the normal's side of a line.
+function clipByLine(poly, origin, normal) {
+  const f = p => (p[0] - origin[0]) * normal[0] + (p[1] - origin[1]) * normal[1]
+  const out = []
+  for (let i = 0; i < poly.length; i++) {
+    const p = poly[i],
+      q = poly[(i + 1) % poly.length]
+    const fp = f(p),
+      fq = f(q)
+    if (fp >= 0) {
+      out.push(p)
+      if (fq < 0) {
+        const t = fp / (fp - fq)
+        out.push([p[0] + t * (q[0] - p[0]), p[1] + t * (q[1] - p[1])])
+      }
+    } else if (fq >= 0) {
+      const t = fp / (fp - fq)
+      out.push([p[0] + t * (q[0] - p[0]), p[1] + t * (q[1] - p[1])])
     }
   }
-  return points
+  return out
+}
+
+// The "safe region" for radius r: valid centers for a circle of radius r that
+// must sit fully inside. Every edge is pushed inward by r and the half-planes
+// intersected, which is exact for convex polygons — the rondel's wedges are
+// triangles. The package solves the general case iteratively, since it also
+// has to cope with concave shapes and their necks.
+function safeRegion(polygon, r) {
+  const orientation = signedArea(polygon) >= 0 ? 1 : -1
+  // Overshoot a hair so the constraint still holds after rounding.
+  const inset = r * (1 + 1e-9)
+  let region = polygon.map(p => [p[0], p[1]])
+  for (let i = 0; i < polygon.length; i++) {
+    const a = polygon[i],
+      b = polygon[(i + 1) % polygon.length]
+    const dx = b[0] - a[0],
+      dy = b[1] - a[1]
+    const len = Math.hypot(dx, dy)
+    if (len === 0) continue
+    const normal = [(-dy / len) * orientation, (dx / len) * orientation]
+    region = clipByLine(
+      region,
+      [a[0] + normal[0] * inset, a[1] + normal[1] * inset],
+      normal
+    )
+    if (region.length < 3) return []
+  }
+  return region
+}
+
+// Projection onto a convex region is exact: keep interior points, and pull
+// anything outside back to the nearest point of its boundary.
+function clampToRegion(region) {
+  const nearest = nearestBoundaryPoint(region)
+  return p => (pointInPolygon(p, region) ? p : nearest(p).point)
+}
+
+// Exact O(n²) check of both constraints. This is what makes the guarantee
+// hard rather than hopeful.
+function verifyPacking(polygon, wallInset, pairDistance, points, epsilon) {
+  const boundary = distanceToBoundary(polygon)
+  let minPairwise = Infinity,
+    minBoundary = Infinity
+  for (let i = 0; i < points.length; i++) {
+    const d = boundary(points[i])
+    if (d < minBoundary) minBoundary = d
+    for (let j = i + 1; j < points.length; j++) {
+      const dd = Math.hypot(
+        points[i][0] - points[j][0],
+        points[i][1] - points[j][1]
+      )
+      if (dd < minPairwise) minPairwise = dd
+    }
+  }
+  return {
+    ok: minPairwise >= pairDistance - epsilon && minBoundary >= wallInset - epsilon,
+    minPairwise,
+    minBoundary
+  }
+}
+
+const BETA = 0.7
+const MAX_SEPARATION_STEPS = 256
+const GOLDEN_ANGLE = 2.399963229728653
+
+// Damped symmetric push-apart, applied all at once (Jacobi, so the result
+// does not depend on iteration order) and clamped back into the safe region.
+// The package walks the Delaunay graph to find close pairs; the counts here
+// are small enough that every pair is cheaper than triangulating.
+function separate(polygon, wallInset, pairDistance, clamp) {
+  const [minX, minY, maxX, maxY] = boundingBox(polygon)
+  const scale = Math.max(maxX - minX, maxY - minY, 1)
+  const epsilon = 1e-9 * scale
+  const delta = 1e-12 * scale
+
+  return input => {
+    let pts = input.map(clamp)
+    for (let step = 0; step < MAX_SEPARATION_STEPS; step++) {
+      if (verifyPacking(polygon, wallInset, pairDistance, pts, epsilon).ok) {
+        return pts
+      }
+      if (pts.length < 2) break
+      const dx = new Float64Array(pts.length)
+      const dy = new Float64Array(pts.length)
+      for (let i = 0; i < pts.length; i++) {
+        for (let j = i + 1; j < pts.length; j++) {
+          const d = Math.hypot(pts[i][0] - pts[j][0], pts[i][1] - pts[j][1])
+          if (d >= pairDistance) continue
+          const push = (BETA * (pairDistance - d)) / 2
+          let ux, uy
+          if (d > delta) {
+            ux = (pts[i][0] - pts[j][0]) / d
+            uy = (pts[i][1] - pts[j][1]) / d
+          } else {
+            // Coincident points need a deterministic direction to split along.
+            ux = Math.cos(i * GOLDEN_ANGLE)
+            uy = Math.sin(i * GOLDEN_ANGLE)
+          }
+          dx[i] += push * ux
+          dy[i] += push * uy
+          dx[j] -= push * ux
+          dy[j] -= push * uy
+        }
+      }
+      pts = pts.map((p, i) =>
+        dx[i] === 0 && dy[i] === 0 ? p : clamp([p[0] + dx[i], p[1] + dy[i]])
+      )
+    }
+    throw new PointilleFitError(
+      `could not arrange ${pts.length} circle centers at pairwise distance >= ${pairDistance}`
+    )
+  }
+}
+
+const BISECTION_STEPS = 14
+
+function pointille(polygon, n, { iterations = 30, seed = 1, radius = 0 } = {}) {
+  if (n <= 0 || polygon.length < 3) return []
+
+  if (radius === 0) {
+    const points = seedPoints(polygon, n, seed, p => pointInPolygon(p, polygon))
+    if (points.length < n) return points
+    return lloydRelax(polygon, iterations, null)(points)
+  }
+
+  const area = Math.abs(signedArea(polygon))
+  if (n * Math.PI * radius * radius > area) {
+    throw new PointilleFitError(
+      `${n} circles of radius ${radius} cannot fit in area ${area.toFixed(3)}`
+    )
+  }
+
+  const boundary = distanceToBoundary(polygon)
+
+  // Solve for an effective radius R: centers >= 2R apart and >= 2R - r from
+  // the boundary. R = r is exactly the base guarantee; anything larger buys
+  // an equal surface gap of 2(R - r) both between circles and against the
+  // wall, which is what stops them hugging the edges.
+  const solve = (R, lloydIterations) => {
+    const wallInset = 2 * R - radius
+    const region = safeRegion(polygon, wallInset)
+    if (region.length < 3) return null
+    const clamp = clampToRegion(region)
+    // Scan the region's own bounding box — in a thin wedge the polygon's box
+    // is mostly outside it, and the scan would spend its budget missing.
+    const seeds = seedPoints(region, n, seed, p => pointInPolygon(p, region))
+    if (seeds.length < n) return null
+    const relaxed = lloydRelax(polygon, lloydIterations, clamp)(seeds)
+    try {
+      return separate(polygon, wallInset, 2 * R, clamp)(relaxed)
+    } catch (e) {
+      if (e instanceof PointilleFitError) return null
+      throw e
+    }
+  }
+
+  const baseline = solve(radius, iterations)
+  if (baseline === null) {
+    throw new PointilleFitError(
+      `could not arrange ${n} non-overlapping circles of radius ${radius}`
+    )
+  }
+
+  // Bisect for the largest feasible R, bounded by area and by the deepest
+  // interior point a deterministic scan can find.
+  const [minX, minY, maxX, maxY] = boundingBox(polygon)
+  let dmax = 0
+  const budget = Math.max(1000, n * 2000)
+  for (let k = 0; k < budget; k++) {
+    const p = [
+      minX + halton(seed + k, 2) * (maxX - minX),
+      minY + halton(seed + k, 3) * (maxY - minY)
+    ]
+    if (pointInPolygon(p, polygon)) {
+      const d = boundary(p)
+      if (d > dmax) dmax = d
+    }
+  }
+  const hi = Math.max(
+    radius,
+    Math.min(Math.sqrt(area / (n * Math.PI)), (dmax + radius) / 2)
+  )
+
+  const probeIterations = Math.min(iterations, 10)
+  let lo = radius,
+    hiBound = hi,
+    bestR = radius,
+    best = baseline
+  for (let step = 0; step < BISECTION_STEPS; step++) {
+    const mid = (lo + hiBound) / 2
+    const attempt = solve(mid, probeIterations)
+    if (attempt !== null) {
+      lo = mid
+      bestR = mid
+      best = attempt
+    } else {
+      hiBound = mid
+    }
+  }
+
+  if (bestR > radius) {
+    const polished = solve(bestR, iterations)
+    if (polished !== null) return polished
+  }
+  return best
 }
 
 function easeInOut(t) {
@@ -367,6 +661,209 @@ export function PointilleRondel() {
       viewBox="-210.5 -210.5 420 420"
       aria-label="A 13-sided rondel with emoji tokens placed in three of its wedges"
     />
+  )
+}
+
+// --- the same rondel, but every token is a circle of a size you pick ---------
+const RONDEL_SIDES = 13
+const RONDEL_R = 200
+// One good per wedge, 3 through 9 of them, cycling around the wheel. All
+// round-ish on purpose: a glyph that fills its em square (🧱, 🃏, ⛏️) paints
+// outside the circle it was placed for, which makes the packing look wrong
+// even when it isn't.
+const RONDEL_TOKENS = [
+  '🪙',
+  '🍊',
+  '🍅',
+  '🫐',
+  '🥚',
+  '🍇',
+  '🌰',
+  '🍪',
+  '🥔',
+  '🧅',
+  '🍒',
+  '🍋',
+  '🧄'
+]
+// Emoji ink measures about 1.25x the font-size, so this draws tokens roughly
+// 28 units across — which is what makes r = 14 the honest description of one.
+const RONDEL_TOKEN_INK = 28
+const RONDEL_TOKEN_SIZE = RONDEL_TOKEN_INK / 1.25
+const MAX_RADIUS = 18
+
+const rondelVertices = () => {
+  const out = []
+  for (let i = 0; i < RONDEL_SIDES; i++) {
+    const a = -Math.PI / 2 - (i * 2 * Math.PI) / RONDEL_SIDES
+    out.push([RONDEL_R * Math.cos(a), RONDEL_R * Math.sin(a)])
+  }
+  return out
+}
+
+const wedgeCount = i => 3 + (i % 7)
+
+// Every wedge is a rotation of the first one about the center, so a layout
+// only has to be solved once per (count, radius) and then spun into place.
+function canonicalLayout(cache, vertices, n, radius) {
+  const key = `${n}:${radius}`
+  if (!cache.has(key)) {
+    const wedge = [[0, 0], vertices[0], vertices[1]]
+    try {
+      cache.set(key, pointille(wedge, n, { iterations: 30, radius }))
+    } catch (e) {
+      if (!(e instanceof PointilleFitError)) throw e
+      cache.set(key, null) // n circles of this size will not fit
+    }
+  }
+  return cache.get(key)
+}
+
+const rotate = (points, angle) => {
+  const c = Math.cos(angle),
+    s = Math.sin(angle)
+  return points.map(([x, y]) => [x * c - y * s, x * s + y * c])
+}
+
+export function PointilleRondelRadius() {
+  const ref = useRef(null)
+  const cache = useRef(new Map())
+  const [radius, setRadius] = useState(RONDEL_TOKEN_INK / 2)
+  const [crowded, setCrowded] = useState(0)
+
+  useEffect(() => {
+    const rondel = ref.current
+    if (!rondel) return
+    rondel.innerHTML = ''
+    const vertices = rondelVertices()
+
+    const wheel = el('g', {})
+    const circleLayer = el('g', {})
+    const tokenLayer = el('g', {})
+    let missing = 0
+
+    for (let i = 0; i < RONDEL_SIDES; i++) {
+      const a = vertices[i],
+        b = vertices[(i + 1) % RONDEL_SIDES]
+      const n = wedgeCount(i)
+      const layout = canonicalLayout(cache.current, vertices, n, radius)
+      if (layout === null) missing++
+
+      wheel.appendChild(
+        el('polyline', {
+          points: `0,0 ${a[0]},${a[1]} ${b[0]},${b[1]} 0,0`,
+          fill: layout === null ? '#fdeeee' : '#fcfcfc',
+          stroke: layout === null ? '#e0a8a8' : '#b3b3b3',
+          'stroke-width': '1'
+        })
+      )
+      if (layout === null) continue
+
+      const positions = rotate(layout, (-i * 2 * Math.PI) / RONDEL_SIDES)
+      positions.forEach(p => {
+        if (radius > 0) {
+          circleLayer.appendChild(
+            el('circle', {
+              cx: p[0],
+              cy: p[1],
+              r: radius,
+              fill: '#e8f2fb',
+              stroke: '#9bb8d0',
+              'stroke-width': '1'
+            })
+          )
+        }
+        const t = el('text', {
+          x: p[0],
+          y: p[1],
+          'text-anchor': 'middle',
+          'dominant-baseline': 'central',
+          'font-size': String(RONDEL_TOKEN_SIZE)
+        })
+        t.textContent = RONDEL_TOKENS[i % RONDEL_TOKENS.length]
+        tokenLayer.appendChild(t)
+      })
+    }
+
+    rondel.appendChild(wheel)
+    rondel.appendChild(circleLayer)
+    rondel.appendChild(tokenLayer)
+    setCrowded(missing)
+  }, [radius])
+
+  const step = delta => () =>
+    setRadius(r => Math.min(MAX_RADIUS, Math.max(0, r + delta)))
+
+  // 44px square is the smallest comfortable tap target, which is the whole
+  // reason these are here — dragging the slider on a phone is a nuisance.
+  const button = {
+    width: 44,
+    height: 44,
+    flex: '0 0 auto',
+    fontSize: '1.1em',
+    lineHeight: 1,
+    fontFamily: 'inherit',
+    border: '1px solid #ccc',
+    borderRadius: '4px',
+    background: '#fafafa',
+    cursor: 'pointer'
+  }
+
+  return (
+    <div style={{ maxWidth: 520, margin: '2em auto' }}>
+      <svg
+        ref={ref}
+        viewBox="-210.5 -210.5 420 420"
+        style={{ width: '100%', display: 'block' }}
+        aria-label={`A 13-sided rondel whose wedges hold 3 to 9 tokens, each token a circle of radius ${radius}`}
+      />
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '.5em',
+          marginTop: '1em',
+          fontFamily: 'monospace'
+        }}
+      >
+        <button
+          type="button"
+          onClick={step(-1)}
+          disabled={radius === 0}
+          aria-label="Decrease radius"
+          style={button}
+        >
+          −
+        </button>
+        <input
+          type="range"
+          min="0"
+          max={MAX_RADIUS}
+          step="1"
+          value={radius}
+          onChange={e => setRadius(+e.target.value)}
+          aria-label="Token radius"
+          style={{ flex: 1, minWidth: 0 }}
+        />
+        <button
+          type="button"
+          onClick={step(1)}
+          disabled={radius === MAX_RADIUS}
+          aria-label="Increase radius"
+          style={button}
+        >
+          +
+        </button>
+        <span style={{ width: '5.5em', textAlign: 'right' }}>r = {radius}</span>
+      </div>
+      <p style={{ fontSize: '.85em', opacity: 0.7, marginTop: '.5em' }}>
+        {radius === 0
+          ? 'At r = 0 the tokens are dimensionless points, so the crowded wedges overlap.'
+          : crowded === 0
+            ? 'Every wedge fits. No two circles overlap, and none crosses a wedge boundary.'
+            : `${crowded} of ${RONDEL_SIDES} wedges cannot fit their tokens at this size.`}
+      </p>
+    </div>
   )
 }
 

--- a/content/2026/pointille-radius.html.mdx
+++ b/content/2026/pointille-radius.html.mdx
@@ -1,0 +1,63 @@
+---
+title: "Pointille: Packing Circles in a Polygon"
+date: 2026-08-02
+tags:
+  - pointille
+  - typescript
+  - circle-packing
+  - voronoi
+  - lloyds-algorithm
+  - geometry
+author: Philihp Busby
+---
+
+Back in [May](/2026/announcing-pointille.html) I wrote about [pointille](https://github.com/philihp/pointille), which spreads `n` points evenly inside a polygon. It solved the problem I had, which was where to put tokens in the wedges of a rondel. Then I put more tokens in a wedge, and it stopped solving the problem I had.
+
+A point has no size. A token does. Two centers can sit a perfectly comfortable distance apart while the things drawn on them lap over each other, and nothing in the library knew or cared. Drag this down to zero and you can watch it happen — the wedges holding eight and nine turn into a pile.
+
+<PointilleRondelRadius />
+
+So there's a `radius` option now.
+
+```typescript
+const centers = pointille(unitSquare, 9, { radius: 0.1 })
+```
+
+It still returns centers. The radius is a constraint on where those centers may go, not something that comes back in the result.
+
+## Two Guarantees
+
+Passing a radius promises two things about the circles you'd draw on the returned centers:
+
+1. Every circle lies completely inside the polygon.
+2. No two circles overlap.
+
+In terms of the centers, that's each one at least `radius` from the boundary, and every pair at least `2 * radius` apart. Both are checked exactly, over every point and every pair, before anything is returned. The iterative parts of the solver are only ever a way of arriving at a layout that passes that check — they aren't trusted to be right on their own.
+
+In the rondel above, the tokens are drawn exactly the size of an `r = 14` circle, which is where the slider starts. Below that you are lying to the library about how big they are, and it obliges you.
+
+## Breathing Room
+
+Satisfying those two constraints exactly turns out to look worse than you'd expect. Circles end up flat against the walls, touching each other, all the slack pooled in one corner. Technically correct, visually miserable.
+
+The fix is to solve a stricter problem than the one you asked for. Internally it picks an effective radius `R` larger than your `r`, and requires centers to be `2R` apart and `2R - r` from the wall. At `R = r` those collapse back to the plain guarantee. Every increment above it buys a surface gap of `2(R - r)` — and because the same `R` drives both constraints, that gap is identical between two circles and between a circle and the wall. Nothing hugs anything.
+
+It then bisects for the largest `R` that still fits, and draws the circle you actually asked for. The empty space is a deliberate result rather than whatever the relaxation happened to leave behind.
+
+## When It Doesn't Fit
+
+Sometimes there is no answer, and then you get a `PointilleFitError`.
+
+The cheap half of that is arithmetic: `n` circles need `n * π * r²` of area, and if that exceeds the polygon's area you can stop immediately. That check is necessary and nowhere close to sufficient. Circles don't tile, and a practical packing tends to top out somewhere around 55–65% of the available area — worse in an awkward shape, and a wedge of a rondel is an awkward shape. So the honest answer is mostly "the solver tried and could not," which is what the rest of the error message says.
+
+Push the slider past 14 and you can watch the failures arrive in order of how crowded a wedge is. The eight- and nine-token wedges give up together, then the sevens, then the sixes, each turning pink as it drops out. The threes and fours never do, at least not before the slider runs out of room.
+
+## Still Deterministic
+
+The original guarantee holds: same polygon, same `n`, same options, same points, forever.
+
+That's less obvious than it was. The bisection is a fixed number of steps against a fixed bound. Seeding is still the Halton sequence, filtered to the region where a center is legal. The push-apart step accumulates every displacement first and applies them together, so no point gets to move before its neighbour and change the outcome. There is no clock and no `Math.random()` anywhere in it.
+
+## Source
+
+The package is on npm as [pointille](https://www.npmjs.com/package/pointille), and source lives at [github.com/philihp/pointille](https://github.com/philihp/pointille). The `radius` option lands in 1.1.0.

--- a/mdx-components.jsx
+++ b/mdx-components.jsx
@@ -2,7 +2,8 @@ import { useMDXComponents as getBlogMDXComponents } from 'nextra-theme-blog'
 import {
   PointilleDemo,
   PointilleFigure,
-  PointilleRondel
+  PointilleRondel,
+  PointilleRondelRadius
 } from './components/pointille'
 
 const blogComponents = getBlogMDXComponents({
@@ -23,6 +24,7 @@ export function useMDXComponents(components) {
     // fall back to a plain blockquote (still styled by the theme's CSS).
     blockquote: props => <blockquote {...props} />,
     PointilleRondel,
+    PointilleRondelRadius,
     PointilleFigure,
     PointilleDemo,
     ...components


### PR DESCRIPTION
A draft follow-up to [Pointille: Evenly Distributing Points in a Polygon](https://www.philihp.com/2026/announcing-pointille.html), covering the `radius` option — points have no size, tokens do, and that gap is what the option closes.

## Changes

- `content/2026/pointille-radius.html.mdx` — the post.
- `components/pointille.jsx` — `PointilleRondelRadius`, the interactive figure, plus circle packing in the vendored algorithm.
- `mdx-components.jsx` — registers the new component.

## The figure

The rondel from the original post, but every wedge holds 3–9 tokens cycling around the wheel, and a control sets the radius. `−` and `+` buttons flank the slider at 44×44 (verified in a 390px mobile viewport, where the slider alone is a nuisance).

The tokens are drawn at exactly the size of an `r = 14` circle, so the slider tells a story on its own:

- **r = 0** — no circles, tokens placed as dimensionless points. The crowded wedges pile up and spill across wedge boundaries. This is the bug.
- **r = 14** — the truth about the tokens. All 13 wedges fit, nothing overlaps, nothing crosses a boundary.
- **r > 14** — you're asking for clearance you don't have. The 8- and 9-token wedges drop out together at 15, sevens at 16, sixes at 17, fives at 18; failed wedges turn pink.

Tokens are all round-ish on purpose — a glyph that fills its em square (🧱, 🃏, ⛏️) paints outside the circle it was placed for and makes a correct packing look broken. Emoji ink measures ~1.25× the font-size, so the size is derived rather than guessed.

## About the vendored algorithm

`components/pointille.jsx` already carried a standalone copy of the algorithm for the figures. This adds the radius path to it: safe region, Jacobi push-apart, bisection for the balanced gap, and an exact `verifyPacking` that every returned layout must pass.

It departs from the package in one place. The package projects points into the safe region iteratively, since it has to handle concave shapes; this computes the region exactly by insetting each edge and intersecting the half-planes, which is only valid for convex polygons. Every wedge is a triangle, so that holds here — and it removes a class of failure the iterative clamp hits in thin wedges, where a center settles a few hundredths short of the wall and fails a layout that is comfortably feasible:

```
before: n=5 largest fitting r=18  failures at r=[13,15,19,20,...]
after:  n=5 largest fitting r=17  failures at r=[18,19,20,...]
```

Those isolated holes would have shown as a wedge vanishing at r=13 and reappearing at 14. Feasibility is now monotone in the radius for every token count, which is what makes the slider read cleanly.

Each wedge is a rotation of its neighbour about the center, so a layout is solved once per (count, radius) and spun into place — 7 solves per radius, not 13 — and memoized so repeat visits to a value are instant.

## Verified

`npm run build` compiles clean. Driven in Chromium against `next start`:

```
r = 14 : 75 circles, 75 tokens — "Every wedge fits."
r = 0  : 0 circles,  75 tokens — "the crowded wedges overlap."
r = 18 : 14 circles, 14 tokens — "9 of 13 wedges cannot fit their tokens at this size."
```

75 is 3+4+5+6+7+8+9 + 3+4+5+6+7+8 across the 13 wedges, and the 14 at r=18 is the four surviving 3- and 4-token wedges. No console or page errors; no horizontal overflow at 390px. Every layout in the post's range passes `verifyPacking` at zero epsilon.

## Before this can go live

The `radius` option is on `main` in [philihp/pointille](https://github.com/philihp/pointille) but is **not published** — npm's latest is 1.0.1 from May, and its `PointilleOptions` has only `iterations` and `seed`. The post says the option lands in 1.1.0, so that release needs cutting first, or the line needs changing.

Marked a draft in the title because the prose is a first pass at your voice, not a finished piece.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhxG3fHfTUEkuweAgj33zi)_